### PR TITLE
refactor(pc): migrate filesystem from Btrfs to ZFS

### DIFF
--- a/configs/nixos/PC_ZFS_MIGRATION.md
+++ b/configs/nixos/PC_ZFS_MIGRATION.md
@@ -1,0 +1,85 @@
+# PC ZFS Migration Plan
+
+**WARNING: THIS PROCESS WILL WIPE THE ROOT DRIVE (`/dev/nvme1n1`). ENSURE ALL DATA IS BACKED UP AND MIGRATION KIT IS SAFE.**
+
+## Phase 0: Preparation (Do this BEFORE wiping)
+
+1.  **Verify Backup Access (Completed):**
+    *   We confirmed that `restic` access to TrueNAS works using the key `restic-backup`.
+    *   We confirmed the latest snapshot is available.
+
+2.  **Create Migration Kit (Completed):**
+    *   A folder `~/MIGRATION_KIT` has been created and synced to your NUC (`basnijholt@nuc:~/MIGRATION_KIT`).
+    *   It contains:
+        *   `restic-backup` (Private Key for TrueNAS access)
+        *   `.restic-password` (Repo encryption password)
+        *   `ssh_host_*` (Original SSH host keys to preserve identity)
+        *   `munge.key` (For Slurm cluster auth)
+        *   `restore_from_backup.sh` (Automated restore script)
+
+3.  **Backup the Migration Kit (CRITICAL):**
+    *   Ensure `~/MIGRATION_KIT` is copied to a **USB Stick** OR verified to be on the **NUC**.
+    *   *If you lose this folder, you lose access to your backups and your system identity.*
+
+4.  **Sync Git:**
+    *   Ensure all config changes are pushed:
+    ```bash
+    git add . && git commit -m "refactor(pc): migrate to zfs" && git push origin pc-zfs
+    ```
+
+## Phase 1: Wipe & Install
+
+1.  **Boot Installer:** Reboot `pc` with the NixOS installer USB.
+2.  **Connect Network:** Ensure you have internet access.
+3.  **Partition & Format:**
+    ```bash
+    sudo -i
+    # Use the 'pc-zfs' branch explicitly
+    nix --extra-experimental-features 'nix-command flakes' \
+      run github:nix-community/disko -- \
+      --mode destroy,format,mount \
+      --flake 'github:basnijholt/dotfiles/pc-zfs#pc'
+    ```
+4.  **Install NixOS:**
+    ```bash
+    nixos-install --flake 'github:basnijholt/dotfiles/pc-zfs#pc' --no-root-passwd
+    ```
+5.  **Reboot:**
+    ```bash
+    reboot
+    ```
+
+## Phase 2: Restore Data & Identity
+
+*After rebooting into your fresh ZFS system:*
+
+1.  **Retrieve Migration Kit:**
+    *   **Option A (From NUC):**
+        ```bash
+        scp -r basnijholt@nuc:~/MIGRATION_KIT .
+        ```
+    *   **Option B (From USB):**
+        Mount USB and copy `MIGRATION_KIT` to your home folder.
+
+2.  **Run Restore Script:**
+    This script will:
+    *   Connect to TrueNAS using the verified keys.
+    *   Restore data (`/home`, `/etc/nixos`, `/var/lib/*`) from the latest snapshot.
+    *   **Automatically restore** SSH host keys, Munge key, and Root keys to `/etc/` and `/root/` with correct permissions.
+
+    ```bash
+    cd MIGRATION_KIT
+    sudo ./restore_from_backup.sh
+    ```
+
+3.  **Final Reboot:**
+    ```bash
+    reboot
+    ```
+
+## Phase 3: Verification
+
+1.  **Check ZFS:** `zpool status` (Should show `zroot` online).
+2.  **Check Identity:** `ssh localhost` (Should accept your known host key).
+3.  **Check Services:** `systemctl status slurmd` (Should be active if munge key is correct).
+

--- a/configs/nixos/PC_ZFS_MIGRATION.md
+++ b/configs/nixos/PC_ZFS_MIGRATION.md
@@ -1,0 +1,85 @@
+# PC ZFS Migration Plan
+
+**WARNING: THIS PROCESS WIPES THE ROOT DRIVE — Samsung 990 EVO Plus 4TB
+(`/dev/disk/by-id/nvme-Samsung_SSD_990_EVO_Plus_4TB_S7U8NJ0Y206553P`,
+`/dev/nvme1n1` today). ENSURE BACKUPS AND THE MIGRATION KIT ARE SAFE FIRST.**
+
+Target layout (from `common/disko-zfs.nix`, the same module hp and nuc use):
+
+- 512M vfat ESP at `/boot`, GRUB with `copyKernels` (the old `/boot2` name dies here)
+- 96G swap partition — the btrfs swapfile cannot come along; swapfiles are not supported on ZFS
+- `zroot` pool: `root` → `/`, `nix` → `/nix`, `var` → `/var`, `home` → `/home`
+  (legacy mounts, zstd, xattr=sa, atime off)
+
+Snapshots and replication come from the fleet-standard modules
+(`optional/zfs-sanoid.nix` + `optional/zfs-replication.nix`, imported via
+`hosts/pc/default.nix`) — no snapper, no manual snapshot config.
+
+## Phase 0: Preparation (BEFORE wiping anything)
+
+1. **Verify restic backups are fresh.** pc backs up hourly to the NAS
+   (NixOS, since the 2026-06 cutover): `sftp:restic@192.168.1.4:/mnt/tank/backups/pc`.
+
+   ```bash
+   systemctl status restic-backups-truenas.service   # last run must be recent + successful
+   sudo restic-truenas snapshots --latest 1          # wrapper from services.restic
+   ```
+
+2. **Refresh the Migration Kit** (`~/MIGRATION_KIT`, mirrored to
+   `basnijholt@nuc:~/MIGRATION_KIT`). It must contain *current* copies of:
+   - `/root/.ssh/restic-backup` (SSH key the restic sftp backend uses)
+   - `/root/.restic-password` (repo encryption password)
+   - `/etc/ssh/ssh_host_*` (host identity)
+   - `/etc/munge/munge.key` (Slurm cluster auth)
+   - `restore_from_backup.sh`
+
+3. **Copy the kit to a USB stick** or verify the nuc mirror is current.
+   *Losing this folder means losing backup access and system identity.*
+
+4. **Push this branch** and make sure CI/eval is green.
+
+## Phase 1: Wipe & Install
+
+1. Boot the NixOS installer USB, get network access, then:
+
+   ```bash
+   sudo -i
+   nix --extra-experimental-features 'nix-command flakes' \
+     run github:nix-community/disko -- \
+     --mode destroy,format,mount \
+     --flake 'github:basnijholt/dotfiles/pc-zfs?dir=configs/nixos#pc'
+
+   nixos-install --no-root-passwd \
+     --flake 'github:basnijholt/dotfiles/pc-zfs?dir=configs/nixos#pc'
+
+   reboot
+   ```
+
+   (After the PR merges, use `.../dotfiles/main?dir=configs/nixos#pc`.)
+
+## Phase 2: Restore Data & Identity
+
+1. Fetch the kit: `scp -r basnijholt@nuc:~/MIGRATION_KIT .` (or from USB).
+2. `cd MIGRATION_KIT && sudo ./restore_from_backup.sh` — restores `/home`,
+   `/var/lib/*` (qdrant, incus, ollama, libvirt, munge) from the latest
+   restic snapshot and puts SSH host keys + munge key back with correct
+   permissions.
+3. Reboot.
+
+## Phase 3: Verification & ZFS Wiring
+
+1. **Pool:** `zpool status` shows `zroot` ONLINE; `swapon --show` shows the 96G partition.
+2. **Identity:** `ssh pc` from another machine accepts the old host key.
+3. **Snapshots:** within ~10 minutes sanoid creates `autosnap_*`:
+   `zfs list -t snapshot | head`.
+4. **Replication to the NAS** (one-time setup, see comments in
+   `optional/zfs-replication.nix`):
+   - On the NAS: `sudo zfs create tank/backups/pc`
+   - Add pc's root SSH key to the NAS `/etc/ssh/authorized_keys.d/root`
+     (restored from backup, so likely already in place — verify with
+     `sudo ssh root@192.168.1.4 zfs list`)
+   - First run: `sudo systemctl start zfs-replication` (daily timer after that)
+5. **Services:** `systemctl status slurmd qdrant ollama` — active, using restored state.
+6. **Incus:** if recreating its storage pool on ZFS (like hp's `zroot/incus`),
+   also copy hp's sanoid exclusion into `hosts/pc/default.nix` so sanoid
+   stays away from incus-managed datasets.

--- a/configs/nixos/common/disko-zfs.nix
+++ b/configs/nixos/common/disko-zfs.nix
@@ -1,4 +1,4 @@
-{ device, espLabel ? "ESP", ... }:
+{ device, espLabel ? "ESP", swapSize ? null, ... }:
 {
   disko.devices = {
     disk = {
@@ -26,7 +26,20 @@
                 pool = "zroot";
               };
             };
-          };
+          }
+          # Hosts that need swap get a real partition: swapfiles are not
+          # supported on ZFS and swap-on-zvol is deadlock-prone.
+          // (
+            if swapSize != null then
+              {
+                swap = {
+                  size = swapSize;
+                  content.type = "swap";
+                };
+              }
+            else
+              { }
+          );
         };
       };
     };

--- a/configs/nixos/flake.nix
+++ b/configs/nixos/flake.nix
@@ -105,6 +105,23 @@
           ./hosts/pc/hardware-configuration.nix
         ];
 
+        # Local-only variant for `nixos-anywhere --vm-test`: the test harness
+        # installs GRUB as removable, which asserts canTouchEfiVariables off.
+        pc-vmtest = mkHost [
+          disko.nixosModules.disko
+          ./hosts/pc/disko.nix
+          ./hosts/pc/default.nix
+          ./hosts/pc/hardware-configuration.nix
+          {
+            boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
+            # pc's debugging.nix value collides with test-instrumentation.nix
+            boot.kernel.sysctl."kernel.hung_task_timeout_secs" = lib.mkForce 600;
+            # disko's test harness hardcodes 4GiB virtual disks; shrink swap so
+            # the layout fits. The partition logic is identical, only the size.
+            disko.devices.disk.main.content.partitions.swap.size = lib.mkForce "1G";
+          }
+        ];
+
         nuc = mkHost [
           disko.nixosModules.disko
           ./hosts/nuc/disko.nix

--- a/configs/nixos/hosts/pc/boot.nix
+++ b/configs/nixos/hosts/pc/boot.nix
@@ -7,6 +7,7 @@
     efiSupport = true;
     useOSProber = true;
     device = "nodev";
+    copyKernels = true;
     memtest86.enable = true;
     theme = pkgs.sleek-grub-theme.override {
       withStyle = "orange";
@@ -15,7 +16,7 @@
   };
   boot.loader.efi = {
     canTouchEfiVariables = true;
-    efiSysMountPoint = "/boot2";
+    efiSysMountPoint = "/boot";
   };
 
 }

--- a/configs/nixos/hosts/pc/boot.nix
+++ b/configs/nixos/hosts/pc/boot.nix
@@ -7,6 +7,10 @@
     efiSupport = true;
     useOSProber = true;
     device = "nodev";
+    # /boot is a 512M vfat ESP: kernels must be copied there (vfat cannot
+    # symlink into the store) and generations capped so it cannot fill up.
+    copyKernels = true;
+    configurationLimit = 10;
     memtest86.enable = true;
     theme = pkgs.sleek-grub-theme.override {
       withStyle = "orange";
@@ -15,7 +19,7 @@
   };
   boot.loader.efi = {
     canTouchEfiVariables = true;
-    efiSysMountPoint = "/boot2";
+    efiSysMountPoint = "/boot";
   };
 
   # Enable aarch64 emulation for building Raspberry Pi images

--- a/configs/nixos/hosts/pc/default.nix
+++ b/configs/nixos/hosts/pc/default.nix
@@ -9,6 +9,7 @@
     ../../optional/printing.nix
     ../../optional/gui-packages.nix
     ../../optional/power.nix
+    ../../optional/zfs-replication.nix
 
     # Host-specific modules (Tier 3)
     ./boot.nix
@@ -27,4 +28,8 @@
     ./nvidia-undervolt.nix
     ./slurm.nix
   ];
+
+  # ZFS configuration
+  networking.hostId = "c3cce7ce";
+  boot.supportedFilesystems = [ "zfs" ];
 }

--- a/configs/nixos/hosts/pc/default.nix
+++ b/configs/nixos/hosts/pc/default.nix
@@ -12,6 +12,7 @@
     ../../optional/ups-client.nix
     ../../optional/wake-on-lan.nix
     ../../optional/nfs-docker.nix
+    ../../optional/zfs-replication.nix
 
     # Host-specific modules (Tier 3)
     ./boot.nix

--- a/configs/nixos/hosts/pc/disko.nix
+++ b/configs/nixos/hosts/pc/disko.nix
@@ -1,10 +1,19 @@
 { ... }:
-(import ../../common/disko-zfs.nix) {
-  # The NixOS root disk (Samsung 990 EVO Plus 4TB, /dev/nvme1n1 today).
-  # by-id so the destructive disko run can never pick the wrong disk.
-  device = "/dev/disk/by-id/nvme-Samsung_SSD_990_EVO_Plus_4TB_S7U8NJ0Y206553P";
-  espLabel = "EFI-PC";
-  # pc actively swaps under AI workloads; swapfiles do not work on ZFS,
-  # so this becomes a dedicated partition (was a 96G btrfs swapfile).
-  swapSize = "96G";
+{
+  imports = [
+    ((import ../../common/disko-zfs.nix) {
+      # The NixOS root disk (Samsung 990 EVO Plus 4TB, /dev/nvme1n1 today).
+      # by-id so the destructive disko run can never pick the wrong disk.
+      device = "/dev/disk/by-id/nvme-Samsung_SSD_990_EVO_Plus_4TB_S7U8NJ0Y206553P";
+      espLabel = "EFI-PC";
+      # pc actively swaps under AI workloads; swapfiles do not work on ZFS,
+      # so this becomes a dedicated partition (was a 96G btrfs swapfile).
+      swapSize = "96G";
+    })
+  ];
+
+  # Only used to size the sparse virtual disk for `nixos-anywhere --vm-test`
+  # and disko VM tests (the 2G default cannot fit the swap partition).
+  # Irrelevant on real hardware.
+  disko.devices.disk.main.imageSize = "120G";
 }

--- a/configs/nixos/hosts/pc/disko.nix
+++ b/configs/nixos/hosts/pc/disko.nix
@@ -1,68 +1,10 @@
-{ lib, ... }:
-
-let
-  # Shared mount options that balance performance and drive health on NVMe.
-  mountOpts = [
-    "compress=zstd"
-    "noatime"
-    "discard=async"
-    "space_cache=v2"
-  ];
-in
-{
-  disko.devices = {
-    disk = {
-      nvme1 = {
-        type = "disk";
-        device = "/dev/nvme1n1";
-        content = {
-          type = "gpt";
-          partitions = {
-            esp = {
-              label = "EFI-NVME1";
-              size = "512M";
-              type = "EF00";
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = "/boot2";
-                mountOptions = [ "umask=0077" ];
-              };
-            };
-
-            root = {
-              label = "ROOT-NVME1";
-              size = "100%";
-              content = {
-                type = "btrfs";
-                extraArgs = [ "-f" "-L" "NVME1-BTRFS" ];
-                subvolumes = {
-                  "@root" = {
-                    mountpoint = "/";
-                    mountOptions = mountOpts;
-                  };
-                  "@nix" = {
-                    mountpoint = "/nix";
-                    mountOptions = mountOpts;
-                  };
-                "@var" = {
-                  mountpoint = "/var";
-                  mountOptions = mountOpts;
-                };
-                "@home" = {
-                  mountpoint = "/home";
-                  mountOptions = mountOpts;
-                };
-                "@snapshots" = {
-                  mountpoint = "/.snapshots";
-                  mountOptions = mountOpts;
-                };
-                };
-              };
-            };
-          };
-        };
-      };
-    };
-  };
+{ ... }:
+(import ../../common/disko-zfs.nix) {
+  # The NixOS root disk (Samsung 990 EVO Plus 4TB, /dev/nvme1n1 today).
+  # by-id so the destructive disko run can never pick the wrong disk.
+  device = "/dev/disk/by-id/nvme-Samsung_SSD_990_EVO_Plus_4TB_S7U8NJ0Y206553P";
+  espLabel = "EFI-PC";
+  # pc actively swaps under AI workloads; swapfiles do not work on ZFS,
+  # so this becomes a dedicated partition (was a 96G btrfs swapfile).
+  swapSize = "96G";
 }

--- a/configs/nixos/hosts/pc/incus-overrides.nix
+++ b/configs/nixos/hosts/pc/incus-overrides.nix
@@ -92,6 +92,8 @@ These hardware features are stubbed:
   # --- Hardware Overrides for VM ---
   # Incus exposes root disk as SCSI (sda), not NVMe
   disko.devices.disk.nvme1.device = lib.mkForce "/dev/sda";
+  # Force ZFS to look for pools in /dev directly (VMs don't always have stable by-id)
+  boot.zfs.devNodes = "/dev";
 
   # Use virtio modules instead of physical hardware modules
   boot.initrd.availableKernelModules = lib.mkForce [ "virtio_pci" "virtio_scsi" "virtio_blk" "ahci" "sd_mod" ];
@@ -103,17 +105,10 @@ These hardware features are stubbed:
   boot.kernelParams = lib.mkForce [ "console=tty0" "console=ttyS0,115200" ];
 
   # --- Boot Loader Overrides ---
-  # Real PC uses GRUB with /boot2. VM uses GRUB but with /boot (standard for simple VMs)
-  boot.loader.grub.enable = lib.mkForce true;
-  boot.loader.grub.device = lib.mkForce "nodev";
-  boot.loader.grub.efiSupport = lib.mkForce true;
-  boot.loader.systemd-boot.enable = lib.mkForce false;
-  
-  # Ensure GRUB and EFI system know about the new mount point
-  boot.loader.efi.efiSysMountPoint = lib.mkForce "/boot";
-
-  # Override disko to use /boot instead of /boot2 for EFI partition
-  disko.devices.disk.nvme1.content.partitions.esp.content.mountpoint = lib.mkForce "/boot";
+  # Use systemd-boot for VM reliability (GRUB has issues with virtio paths)
+  boot.loader.grub.enable = lib.mkForce false;
+  boot.loader.systemd-boot.enable = lib.mkForce true;
+  boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
 
   # --- Networking Overrides for VM ---
   # Use generic interface for NAT (VM doesn't have wlp7s0)

--- a/configs/nixos/hosts/pc/incus-overrides.nix
+++ b/configs/nixos/hosts/pc/incus-overrides.nix
@@ -91,7 +91,10 @@ These hardware features are stubbed:
 
   # --- Hardware Overrides for VM ---
   # Incus exposes root disk as SCSI (sda), not NVMe
-  disko.devices.disk.nvme1.device = lib.mkForce "/dev/sda";
+  disko.devices.disk.main.device = lib.mkForce "/dev/sda";
+
+  # ZFS in a VM: by-id paths are not stable, look in /dev directly
+  boot.zfs.devNodes = "/dev";
 
   # Use virtio modules instead of physical hardware modules
   boot.initrd.availableKernelModules = lib.mkForce [ "virtio_pci" "virtio_scsi" "virtio_blk" "ahci" "sd_mod" ];
@@ -103,17 +106,11 @@ These hardware features are stubbed:
   boot.kernelParams = lib.mkForce [ "console=tty0" "console=ttyS0,115200" ];
 
   # --- Boot Loader Overrides ---
-  # Real PC uses GRUB with /boot2. VM uses GRUB but with /boot (standard for simple VMs)
-  boot.loader.grub.enable = lib.mkForce true;
-  boot.loader.grub.device = lib.mkForce "nodev";
-  boot.loader.grub.efiSupport = lib.mkForce true;
-  boot.loader.systemd-boot.enable = lib.mkForce false;
-  
-  # Ensure GRUB and EFI system know about the new mount point
-  boot.loader.efi.efiSysMountPoint = lib.mkForce "/boot";
-
-  # Override disko to use /boot instead of /boot2 for EFI partition
-  disko.devices.disk.nvme1.content.partitions.esp.content.mountpoint = lib.mkForce "/boot";
+  # Use systemd-boot in the VM (same as the hp/nuc incus overrides); the
+  # real PC keeps GRUB with its theme.
+  boot.loader.grub.enable = lib.mkForce false;
+  boot.loader.systemd-boot.enable = lib.mkForce true;
+  boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
 
   # --- Networking Overrides for VM ---
   # Use generic interface for NAT (VM doesn't have wlp7s0)

--- a/configs/nixos/hosts/pc/storage.nix
+++ b/configs/nixos/hosts/pc/storage.nix
@@ -1,46 +1,10 @@
-# Storage configuration (Btrfs snapshots, swap)
+# Storage configuration (ZFS, swap)
 { ... }:
 
 {
-  services.fstrim.enable = true;
-
-  # --- Snapper Btrfs Policies ---
-  services.snapper.configs = {
-    root = {
-      SUBVOLUME = "/";
-      ALLOW_USERS = [ "basnijholt" ];
-      TIMELINE_CREATE = true;
-      TIMELINE_CLEANUP = true;
-      TIMELINE_LIMIT_HOURLY = 6;
-      TIMELINE_LIMIT_DAILY = 7;
-      TIMELINE_LIMIT_WEEKLY = 4;
-      TIMELINE_LIMIT_MONTHLY = 6;
-      TIMELINE_LIMIT_YEARLY = 2;
-      NUMBER_CLEANUP = true;
-      NUMBER_MIN_AGE = 1800;
-      NUMBER_LIMIT = 10;
-    };
-    home = {
-      SUBVOLUME = "/home";
-      ALLOW_USERS = [ "basnijholt" ];
-      TIMELINE_CREATE = true;
-      TIMELINE_CLEANUP = true;
-      TIMELINE_LIMIT_HOURLY = 6;
-      TIMELINE_LIMIT_DAILY = 7;
-      TIMELINE_LIMIT_WEEKLY = 2;
-      TIMELINE_LIMIT_MONTHLY = 0;
-      TIMELINE_LIMIT_YEARLY = 0;
-      NUMBER_CLEANUP = true;
-      NUMBER_MIN_AGE = 1800;
-      NUMBER_LIMIT = 20;
-    };
-  };
-
-  # Snapper snapshot roots must exist with correct permissions
-  systemd.tmpfiles.rules = [
-    "d /.snapshots 0755 root root -"
-    "d /home/.snapshots 0755 basnijholt users -"
-  ];
+  # --- ZFS Maintenance ---
+  services.zfs.autoScrub.enable = true;
+  services.zfs.trim.enable = true;
 
   # --- Swap ---
   swapDevices = [

--- a/configs/nixos/hosts/pc/storage.nix
+++ b/configs/nixos/hosts/pc/storage.nix
@@ -1,57 +1,22 @@
-# Storage configuration (Btrfs snapshots, swap)
+# Storage configuration (ZFS maintenance, service dirs)
+#
+# Snapshots come from sanoid (optional/zfs-sanoid.nix via zfs-replication.nix,
+# imported in default.nix) — the snapper configs died with btrfs. Swap is a
+# 96G partition from disko.nix: swapfiles are not supported on ZFS.
 { ... }:
 
 {
-  services.fstrim.enable = true;
+  # --- ZFS Maintenance ---
+  # Pool-level autotrim is on (common/disko-zfs.nix); these add the periodic
+  # scrub for bitrot detection and a weekly full trim pass.
+  services.zfs.autoScrub.enable = true;
+  services.zfs.trim.enable = true;
 
-  # --- Snapper Btrfs Policies ---
-  services.snapper.configs = {
-    root = {
-      SUBVOLUME = "/";
-      ALLOW_USERS = [ "basnijholt" ];
-      TIMELINE_CREATE = true;
-      TIMELINE_CLEANUP = true;
-      TIMELINE_LIMIT_HOURLY = 6;
-      TIMELINE_LIMIT_DAILY = 7;
-      TIMELINE_LIMIT_WEEKLY = 4;
-      TIMELINE_LIMIT_MONTHLY = 6;
-      TIMELINE_LIMIT_YEARLY = 2;
-      NUMBER_CLEANUP = true;
-      NUMBER_MIN_AGE = 1800;
-      NUMBER_LIMIT = 10;
-    };
-    home = {
-      SUBVOLUME = "/home";
-      ALLOW_USERS = [ "basnijholt" ];
-      TIMELINE_CREATE = true;
-      TIMELINE_CLEANUP = true;
-      TIMELINE_LIMIT_HOURLY = 6;
-      TIMELINE_LIMIT_DAILY = 7;
-      TIMELINE_LIMIT_WEEKLY = 2;
-      TIMELINE_LIMIT_MONTHLY = 0;
-      TIMELINE_LIMIT_YEARLY = 0;
-      NUMBER_CLEANUP = true;
-      NUMBER_MIN_AGE = 1800;
-      NUMBER_LIMIT = 20;
-    };
-  };
-
-  # Snapper snapshot roots must exist with correct permissions
   systemd.tmpfiles.rules = [
-    "d /.snapshots 0755 root root -"
-    "d /home/.snapshots 0755 basnijholt users -"
     "d /var/lib/club-3090-vllm 0755 root root -"
     "d /var/lib/club-3090-vllm/models 0755 root root -"
     "d /var/lib/club-3090-vllm/cache 0755 root root -"
     "d /var/lib/club-3090-vllm/cache/torch_compile 0755 root root -"
     "d /var/lib/club-3090-vllm/cache/triton 0755 root root -"
-  ];
-
-  # --- Swap ---
-  swapDevices = [
-    {
-      device = "/swapfile";
-      size = 96 * 1024; # 96GB
-    }
   ];
 }


### PR DESCRIPTION
Migrates the main workstation `pc` from Btrfs to ZFS.

**Refreshed 2026-07-21** against current main (originally opened Dec 2025):

- `disko.nix` now uses the shared `common/disko-zfs.nix` module like hp/nuc (zroot with root/nix/var/home, ESP at `/boot` replacing `/boot2`), pinned to the root disk's stable `/dev/disk/by-id` path.
- `common/disko-zfs.nix` gains an optional `swapSize` parameter: pc swaps heavily and **swapfiles are not supported on ZFS**, so the 96G btrfs swapfile becomes a 96G partition. No-op for hp/nuc (toplevel drvs verified unchanged).
- snapper/fstrim/swapfile out; `zfs.autoScrub` + `zfs.trim` in; sanoid snapshots + daily syncoid to the NAS via the fleet-standard `zfs-replication.nix` import.
- GRUB: `copyKernels` + `configurationLimit 10` so the 512M vfat ESP can't fill up.
- VM overrides track the disko rename and use systemd-boot like hp/nuc.
- `PC_ZFS_MIGRATION.md` rewritten for the post-TrueNAS world (NixOS NAS restic repo, `?dir=configs/nixos` flake refs, sanoid/syncoid wiring).