### PR TITLE
Pin bootstrap.sh to exact commit SHA for security

### DIFF
--- a/.github/scripts/sync_public_branch.py
+++ b/.github/scripts/sync_public_branch.py
@@ -135,12 +135,11 @@ def main() -> int:
         content = bootstrap.read_text()
         # Replace entire clone block with init+fetch of specific commit
         old_clone = '''log "Cloning dotfiles ($DOTFILES_BRANCH) into $DOTFILES_DIR..."
-GIT_LFS_SKIP_SMUDGE=1 git clone --depth=1 --branch "$DOTFILES_BRANCH" --single-branch \\
-  "$DOTFILES_REPO" "$DOTFILES_DIR"'''
+git clone --depth=1 --branch "$DOTFILES_BRANCH" --single-branch "$DOTFILES_REPO" "$DOTFILES_DIR"'''
         new_clone = f'''log "Cloning dotfiles (commit {full_sha}) into $DOTFILES_DIR..."
 git init "$DOTFILES_DIR"
 git -C "$DOTFILES_DIR" remote add origin "$DOTFILES_REPO"
-GIT_LFS_SKIP_SMUDGE=1 git -C "$DOTFILES_DIR" fetch --depth=1 origin {full_sha}
+git -C "$DOTFILES_DIR" fetch --depth=1 origin {full_sha}
 git -C "$DOTFILES_DIR" checkout FETCH_HEAD'''
         if old_clone not in content:
             raise RuntimeError("Could not find clone block in bootstrap.sh")

--- a/.github/scripts/sync_public_branch.py
+++ b/.github/scripts/sync_public_branch.py
@@ -133,16 +133,18 @@ def main() -> int:
     if bootstrap.exists():
         log(f"Pinning bootstrap.sh to commit {full_sha}")
         content = bootstrap.read_text()
-        marker = '"$DOTFILES_REPO" "$DOTFILES_DIR"'
-        if marker not in content:
-            raise RuntimeError(f"Could not find '{marker}' in bootstrap.sh")
-        # Add checkout of specific commit after clone
-        content = content.replace(
-            marker,
-            f"{marker}\n"
-            f'git -C "$DOTFILES_DIR" fetch --depth=1 origin {full_sha} && '
-            'git -C "$DOTFILES_DIR" checkout FETCH_HEAD',
-        )
+        # Replace entire clone block with init+fetch of specific commit
+        old_clone = '''log "Cloning dotfiles ($DOTFILES_BRANCH) into $DOTFILES_DIR..."
+GIT_LFS_SKIP_SMUDGE=1 git clone --depth=1 --branch "$DOTFILES_BRANCH" --single-branch \\
+  "$DOTFILES_REPO" "$DOTFILES_DIR"'''
+        new_clone = f'''log "Cloning dotfiles (commit {full_sha}) into $DOTFILES_DIR..."
+git init "$DOTFILES_DIR"
+git -C "$DOTFILES_DIR" remote add origin "$DOTFILES_REPO"
+GIT_LFS_SKIP_SMUDGE=1 git -C "$DOTFILES_DIR" fetch --depth=1 origin {full_sha}
+git -C "$DOTFILES_DIR" checkout FETCH_HEAD'''
+        if old_clone not in content:
+            raise RuntimeError("Could not find clone block in bootstrap.sh")
+        content = content.replace(old_clone, new_clone)
         bootstrap.write_text(content)
 
     # 3) Commit and push if there are changes

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -86,16 +86,14 @@ fi
 # --- Clone and setup ---
 log "Initializing Git LFS..."
 git lfs install || true
+export GIT_LFS_SKIP_SMUDGE=1
 
 log "Cloning dotfiles ($DOTFILES_BRANCH) into $DOTFILES_DIR..."
-GIT_LFS_SKIP_SMUDGE=1 git clone --depth=1 --branch "$DOTFILES_BRANCH" --single-branch \
-  "$DOTFILES_REPO" "$DOTFILES_DIR"
+git clone --depth=1 --branch "$DOTFILES_BRANCH" --single-branch "$DOTFILES_REPO" "$DOTFILES_DIR"
 
 log "Initializing submodules..."
-GIT_LFS_SKIP_SMUDGE=1 git -C "$DOTFILES_DIR" submodule update --init --recursive --depth=1 --jobs 8 || {
-  log "Warning: Some submodules failed. Retrying sequentially..."
-  GIT_LFS_SKIP_SMUDGE=1 git -C "$DOTFILES_DIR" submodule update --init --recursive --depth=1 || true
-}
+git -C "$DOTFILES_DIR" submodule update --init --recursive --depth=1 --jobs 8 ||
+  git -C "$DOTFILES_DIR" submodule update --init --recursive --depth=1 || true
 
 # --- Fetch platform-specific binaries ---
 if [[ -n "$DOTBINS_ARCH" ]]; then

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -94,6 +94,7 @@ git clone --depth=1 --branch "$DOTFILES_BRANCH" --single-branch "$DOTFILES_REPO"
 log "Initializing submodules..."
 git -C "$DOTFILES_DIR" submodule update --init --recursive --depth=1 --jobs 8 ||
   git -C "$DOTFILES_DIR" submodule update --init --recursive --depth=1 || true
+unset GIT_LFS_SKIP_SMUDGE
 
 # --- Fetch platform-specific binaries ---
 if [[ -n "$DOTBINS_ARCH" ]]; then


### PR DESCRIPTION
## Summary
- CI now replaces the clone block in bootstrap.sh with init+fetch of the exact commit SHA
- Prevents branch tampering or MITM attacks on the public branch
- Simplified clone/submodule block with exported GIT_LFS_SKIP_SMUDGE

## Test plan
- [ ] Merge and verify workflow runs successfully
- [ ] Test bootstrap with: `cd /tmp && rm -rf dotfiles-test && git init dotfiles-test && git -C dotfiles-test remote add origin https://github.com/basnijholt/dotfiles.git && git -C dotfiles-test fetch --depth=1 origin <sha> && git -C dotfiles-test checkout FETCH_HEAD`

🤖 Generated with [Claude Code](https://claude.ai/code)