### PR TITLE
Add separate Hetzner SaaS NixOS host

### DIFF
--- a/configs/nixos/flake.nix
+++ b/configs/nixos/flake.nix
@@ -189,6 +189,15 @@
           ./hosts/hetzner/hardware-configuration.nix
         ];
 
+        # Hetzner Cloud VPS (ARM) - single-node K3s host for MindRoom SaaS
+        hetzner-saas = mkHostArm [
+          disko.nixosModules.disko
+          ./hosts/hetzner/disko.nix
+          ./hosts/hetzner/default.nix
+          ./hosts/hetzner-saas/default.nix
+          ./hosts/hetzner/hardware-configuration.nix
+        ];
+
         # Paul's Wyse 5070 - gateway to home services via Tailscale
         paul-wyse = mkHost [
           disko.nixosModules.disko

--- a/configs/nixos/flake.nix
+++ b/configs/nixos/flake.nix
@@ -195,12 +195,15 @@
         ];
 
         # Hetzner Cloud VPS (x86_64) - single-node K3s host for MindRoom SaaS
-        hetzner-saas = mkHost [
-          disko.nixosModules.disko
-          ./hosts/hetzner-saas/disko.nix
-          ./hosts/hetzner-saas/default.nix
-          ./hosts/hetzner-saas/hardware-configuration.nix
-        ];
+        hetzner-saas = lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            disko.nixosModules.disko
+            ./hosts/hetzner-saas/disko.nix
+            ./hosts/hetzner-saas/default.nix
+            ./hosts/hetzner-saas/hardware-configuration.nix
+          ];
+        };
 
         # Minimal first-stage config for nixos-anywhere in rescue mode.
         hetzner-saas-bootstrap = lib.nixosSystem {

--- a/configs/nixos/flake.nix
+++ b/configs/nixos/flake.nix
@@ -49,31 +49,36 @@
         }
       ];
 
-      mkHost = extraModules:
+      mkHost =
+        extraModules:
         lib.nixosSystem {
           inherit system;
           modules = commonModules ++ extraModules;
         };
 
-      mkHostArm = extraModules:
+      mkHostArm =
+        extraModules:
         lib.nixosSystem {
           system = "aarch64-linux";
           modules = commonModules ++ extraModules;
         };
 
-      mkPi = piModule: extraModules:
+      mkPi =
+        piModule: extraModules:
         nixos-raspberrypi.lib.nixosSystem {
           specialArgs = { inherit nixos-raspberrypi; };
           modules = [ piModule ] ++ commonModules ++ extraModules;
         };
 
-      mkPiInstaller = piModule: extraModules:
+      mkPiInstaller =
+        piModule: extraModules:
         nixos-raspberrypi.lib.nixosInstaller {
           specialArgs = { inherit nixos-raspberrypi; };
           modules = [ piModule ] ++ extraModules;
         };
 
-    in {
+    in
+    {
       nixosConfigurations = {
         pc = mkHost [
           disko.nixosModules.disko
@@ -189,14 +194,25 @@
           ./hosts/hetzner/hardware-configuration.nix
         ];
 
-        # Hetzner Cloud VPS (ARM) - single-node K3s host for MindRoom SaaS
-        hetzner-saas = mkHostArm [
+        # Hetzner Cloud VPS (x86_64) - single-node K3s host for MindRoom SaaS
+        hetzner-saas = mkHost [
           disko.nixosModules.disko
-          ./hosts/hetzner/disko.nix
-          ./hosts/hetzner/default.nix
+          ./hosts/hetzner-saas/disko.nix
           ./hosts/hetzner-saas/default.nix
-          ./hosts/hetzner/hardware-configuration.nix
+          ./hosts/hetzner-saas/hardware-configuration.nix
         ];
+
+        # Minimal first-stage config for nixos-anywhere in rescue mode.
+        hetzner-saas-bootstrap = lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            disko.nixosModules.disko
+            ./hosts/hetzner-saas/disko.nix
+            ./hosts/hetzner-saas/networking.nix
+            ./hosts/hetzner-saas/hardware-configuration.nix
+            ./hosts/hetzner/bootstrap.nix
+          ];
+        };
 
         # Paul's Wyse 5070 - gateway to home services via Tailscale
         paul-wyse = mkHost [

--- a/configs/nixos/hosts/hetzner-saas/default.nix
+++ b/configs/nixos/hosts/hetzner-saas/default.nix
@@ -5,7 +5,6 @@ let
 in
 {
   imports = [
-    ../../optional/zfs-auto-snapshot.nix
     ./networking.nix
   ];
 
@@ -98,8 +97,6 @@ in
   };
   systemd.services."systemd-zram-setup@zram0".restartIfChanged = false;
 
-  networking.hostId = "5d9d75a1";
-  boot.zfs.requestEncryptionCredentials = false;
   boot.kernelModules = [ "tcp_bbr" ];
   boot.kernel.sysctl = {
     "kernel.sysrq" = 1;

--- a/configs/nixos/hosts/hetzner-saas/default.nix
+++ b/configs/nixos/hosts/hetzner-saas/default.nix
@@ -1,6 +1,11 @@
 { lib, pkgs, ... }:
 
 {
+  imports = [
+    ../../optional/zfs-auto-snapshot.nix
+    ./networking.nix
+  ];
+
   networking.hostName = lib.mkForce "hetzner-saas";
 
   services.k3s = {
@@ -15,15 +20,31 @@
   environment.systemPackages = with pkgs; [
     kubectl
     kubernetes-helm
+    k9s
   ];
 
-  networking.firewall = {
-    trustedInterfaces = [ "cni0" "flannel.1" ];
-    allowedTCPPorts = lib.mkForce (
-      [ 22 80 443 6443 ]
-      ++ [ 20 21 ]
-      ++ (lib.range 21100 21110)
-    );
-    allowedUDPPorts = [ 8472 ];
+  virtualisation.docker.enable = true;
+
+  services.fwupd.enable = lib.mkForce false;
+  services.syncthing.enable = lib.mkForce false;
+
+  services.openssh.settings = {
+    UseDns = lib.mkForce false;
+    PermitRootLogin = lib.mkForce "prohibit-password";
   };
+
+  nix.settings.substituters = lib.mkForce [
+    "https://cache.nixos.org/"
+    "https://nix-community.cachix.org"
+  ];
+  nix.settings.max-jobs = 1;
+  nix.settings.cores = 2;
+
+  zramSwap = {
+    enable = true;
+    memoryPercent = 50;
+  };
+  systemd.services."systemd-zram-setup@zram0".restartIfChanged = false;
+
+  networking.hostId = "5d9d75a1";
 }

--- a/configs/nixos/hosts/hetzner-saas/default.nix
+++ b/configs/nixos/hosts/hetzner-saas/default.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, ... }:
+
+{
+  networking.hostName = lib.mkForce "hetzner-saas";
+
+  services.k3s = {
+    enable = true;
+    role = "server";
+    extraFlags = [
+      "--disable=traefik"
+      "--write-kubeconfig-mode=0644"
+    ];
+  };
+
+  environment.systemPackages = with pkgs; [
+    kubectl
+    kubernetes-helm
+  ];
+
+  networking.firewall = {
+    trustedInterfaces = [ "cni0" "flannel.1" ];
+    allowedTCPPorts = lib.mkForce (
+      [ 22 80 443 6443 ]
+      ++ [ 20 21 ]
+      ++ (lib.range 21100 21110)
+    );
+    allowedUDPPorts = [ 8472 ];
+  };
+}

--- a/configs/nixos/hosts/hetzner-saas/default.nix
+++ b/configs/nixos/hosts/hetzner-saas/default.nix
@@ -1,12 +1,73 @@
 { lib, pkgs, ... }:
 
+let
+  sshKeys = (import ../../common/ssh-keys.nix).sshKeys;
+in
 {
   imports = [
     ../../optional/zfs-auto-snapshot.nix
     ./networking.nix
   ];
 
+  system.stateVersion = "25.05";
   networking.hostName = lib.mkForce "hetzner-saas";
+
+  time.timeZone = "America/Los_Angeles";
+  i18n.defaultLocale = "en_US.UTF-8";
+  nixpkgs.config.allowUnfree = true;
+
+  nix.settings = {
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+    trusted-users = [
+      "root"
+      "basnijholt"
+    ];
+    fallback = true;
+    substituters = [
+      "https://cache.nixos.org/"
+      "https://nix-community.cachix.org"
+    ];
+    trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+    max-jobs = 1;
+    cores = 2;
+  };
+
+  users.users.basnijholt = {
+    isNormalUser = true;
+    description = "Bas Nijholt";
+    extraGroups = [
+      "wheel"
+      "docker"
+    ];
+    shell = pkgs.zsh;
+    openssh.authorizedKeys.keys = sshKeys;
+  };
+  users.users.root.openssh.authorizedKeys.keys = sshKeys;
+  security.sudo.wheelNeedsPassword = false;
+
+  programs.zsh.enable = true;
+
+  services.openssh = {
+    enable = true;
+    openFirewall = true;
+    settings = {
+      PasswordAuthentication = false;
+      PermitRootLogin = lib.mkForce "prohibit-password";
+      UseDns = lib.mkForce false;
+    };
+  };
+
+  services.earlyoom = {
+    enable = true;
+    freeSwapThreshold = 10;
+    freeMemThreshold = 10;
+  };
 
   services.k3s = {
     enable = true;
@@ -18,27 +79,18 @@
   };
 
   environment.systemPackages = with pkgs; [
+    curl
+    git
+    htop
+    jq
     kubectl
     kubernetes-helm
     k9s
+    ripgrep
+    vim
   ];
 
   virtualisation.docker.enable = true;
-
-  services.fwupd.enable = lib.mkForce false;
-  services.syncthing.enable = lib.mkForce false;
-
-  services.openssh.settings = {
-    UseDns = lib.mkForce false;
-    PermitRootLogin = lib.mkForce "prohibit-password";
-  };
-
-  nix.settings.substituters = lib.mkForce [
-    "https://cache.nixos.org/"
-    "https://nix-community.cachix.org"
-  ];
-  nix.settings.max-jobs = 1;
-  nix.settings.cores = 2;
 
   zramSwap = {
     enable = true;
@@ -47,4 +99,10 @@
   systemd.services."systemd-zram-setup@zram0".restartIfChanged = false;
 
   networking.hostId = "5d9d75a1";
+  boot.zfs.requestEncryptionCredentials = false;
+  boot.kernelModules = [ "tcp_bbr" ];
+  boot.kernel.sysctl = {
+    "kernel.sysrq" = 1;
+    "net.ipv4.tcp_congestion_control" = "bbr";
+  };
 }

--- a/configs/nixos/hosts/hetzner-saas/disko.nix
+++ b/configs/nixos/hosts/hetzner-saas/disko.nix
@@ -1,7 +1,7 @@
-# Hetzner Cloud x86_64 disk configuration with ZFS.
+# Hetzner Cloud x86_64 disk configuration.
 #
 # Hetzner Cloud x86_64 instances boot through legacy BIOS, so GRUB needs a
-# BIOS boot partition on GPT in addition to /boot.
+# BIOS boot partition on GPT.
 { ... }:
 
 {
@@ -16,65 +16,14 @@
             size = "1M";
             type = "EF02";
           };
-          boot = {
-            label = "BOOT-SAAS";
-            size = "512M";
-            type = "EF00";
-            content = {
-              type = "filesystem";
-              format = "vfat";
-              mountpoint = "/boot";
-              mountOptions = [ "umask=0077" ];
-            };
-          };
-          zfs = {
+          root = {
             size = "100%";
             content = {
-              type = "zfs";
-              pool = "zroot";
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/";
             };
           };
-        };
-      };
-    };
-
-    zpool.zroot = {
-      type = "zpool";
-      mode = "";
-      options = {
-        ashift = "12";
-        autotrim = "on";
-      };
-      rootFsOptions = {
-        compression = "zstd";
-        "com.sun:auto-snapshot" = "true";
-        acltype = "posixacl";
-        xattr = "sa";
-        atime = "off";
-      };
-      datasets = {
-        root = {
-          type = "zfs_fs";
-          mountpoint = "/";
-          options.mountpoint = "legacy";
-        };
-        nix = {
-          type = "zfs_fs";
-          mountpoint = "/nix";
-          options = {
-            mountpoint = "legacy";
-            "com.sun:auto-snapshot" = "false";
-          };
-        };
-        var = {
-          type = "zfs_fs";
-          mountpoint = "/var";
-          options.mountpoint = "legacy";
-        };
-        home = {
-          type = "zfs_fs";
-          mountpoint = "/home";
-          options.mountpoint = "legacy";
         };
       };
     };

--- a/configs/nixos/hosts/hetzner-saas/disko.nix
+++ b/configs/nixos/hosts/hetzner-saas/disko.nix
@@ -1,0 +1,82 @@
+# Hetzner Cloud x86_64 disk configuration with ZFS.
+#
+# Hetzner Cloud x86_64 instances boot through legacy BIOS, so GRUB needs a
+# BIOS boot partition on GPT in addition to /boot.
+{ ... }:
+
+{
+  disko.devices = {
+    disk.main = {
+      type = "disk";
+      device = "/dev/sda";
+      content = {
+        type = "gpt";
+        partitions = {
+          bios = {
+            size = "1M";
+            type = "EF02";
+          };
+          boot = {
+            label = "BOOT-SAAS";
+            size = "512M";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "umask=0077" ];
+            };
+          };
+          zfs = {
+            size = "100%";
+            content = {
+              type = "zfs";
+              pool = "zroot";
+            };
+          };
+        };
+      };
+    };
+
+    zpool.zroot = {
+      type = "zpool";
+      mode = "";
+      options = {
+        ashift = "12";
+        autotrim = "on";
+      };
+      rootFsOptions = {
+        compression = "zstd";
+        "com.sun:auto-snapshot" = "true";
+        acltype = "posixacl";
+        xattr = "sa";
+        atime = "off";
+      };
+      datasets = {
+        root = {
+          type = "zfs_fs";
+          mountpoint = "/";
+          options.mountpoint = "legacy";
+        };
+        nix = {
+          type = "zfs_fs";
+          mountpoint = "/nix";
+          options = {
+            mountpoint = "legacy";
+            "com.sun:auto-snapshot" = "false";
+          };
+        };
+        var = {
+          type = "zfs_fs";
+          mountpoint = "/var";
+          options.mountpoint = "legacy";
+        };
+        home = {
+          type = "zfs_fs";
+          mountpoint = "/home";
+          options.mountpoint = "legacy";
+        };
+      };
+    };
+  };
+}

--- a/configs/nixos/hosts/hetzner-saas/disko.nix
+++ b/configs/nixos/hosts/hetzner-saas/disko.nix
@@ -1,7 +1,6 @@
 # Hetzner Cloud x86_64 disk configuration.
 #
-# Hetzner Cloud x86_64 instances boot through legacy BIOS, so GRUB needs a
-# BIOS boot partition on GPT.
+# CPX instances boot through UEFI, so keep a small ESP mounted at /boot.
 { ... }:
 
 {
@@ -12,9 +11,16 @@
       content = {
         type = "gpt";
         partitions = {
-          bios = {
-            size = "1M";
-            type = "EF02";
+          esp = {
+            label = "ESP-SAAS";
+            size = "512M";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "umask=0077" ];
+            };
           };
           root = {
             size = "100%";

--- a/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
+++ b/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
@@ -22,12 +22,14 @@
   ];
 
   boot.loader = {
-    grub = {
+    systemd-boot = {
       enable = true;
-      device = lib.mkForce "";
       configurationLimit = 3;
     };
-    efi.canTouchEfiVariables = false;
+    efi = {
+      canTouchEfiVariables = true;
+      efiSysMountPoint = "/boot";
+    };
   };
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";

--- a/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
+++ b/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
@@ -1,0 +1,34 @@
+# Hetzner Cloud x86_64 guest configuration.
+{ lib, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  boot.initrd.availableKernelModules = [
+    "virtio_pci"
+    "virtio_scsi"
+    "virtio_blk"
+    "sd_mod"
+    "sr_mod"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+  boot.kernelParams = [ "console=ttyS0,115200" ];
+
+  boot.supportedFilesystems = [ "zfs" ];
+  boot.zfs.forceImportRoot = false;
+
+  boot.loader = {
+    grub = {
+      enable = true;
+      device = lib.mkForce "";
+      configurationLimit = 3;
+    };
+    efi.canTouchEfiVariables = false;
+  };
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
+++ b/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
@@ -16,7 +16,10 @@
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ ];
   boot.extraModulePackages = [ ];
-  boot.kernelParams = [ "console=ttyS0,115200" ];
+  boot.kernelParams = [
+    "console=ttyS0,115200"
+    "net.ifnames=0"
+  ];
 
   boot.loader = {
     grub = {

--- a/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
+++ b/configs/nixos/hosts/hetzner-saas/hardware-configuration.nix
@@ -18,9 +18,6 @@
   boot.extraModulePackages = [ ];
   boot.kernelParams = [ "console=ttyS0,115200" ];
 
-  boot.supportedFilesystems = [ "zfs" ];
-  boot.zfs.forceImportRoot = false;
-
   boot.loader = {
     grub = {
       enable = true;

--- a/configs/nixos/hosts/hetzner-saas/networking.nix
+++ b/configs/nixos/hosts/hetzner-saas/networking.nix
@@ -1,0 +1,42 @@
+# Hetzner Cloud networking configuration for the MindRoom SaaS K3s host.
+{ lib, ... }:
+
+{
+  networking.hostName = "hetzner-saas";
+
+  systemd.network.enable = true;
+  networking.useDHCP = lib.mkDefault false;
+
+  systemd.network.networks."30-wan" = {
+    matchConfig.Name = "en* eth*";
+    networkConfig = {
+      DHCP = "ipv4";
+      DNS = [
+        "1.1.1.1"
+        "8.8.8.8"
+      ];
+    };
+  };
+
+  networking.nameservers = lib.mkForce [
+    "1.1.1.1"
+    "8.8.8.8"
+    "100.100.100.100"
+  ];
+
+  networking.firewall = {
+    enable = true;
+    trustedInterfaces = [
+      "cni0"
+      "flannel.1"
+    ];
+    allowedTCPPorts = [
+      22
+      80
+      443
+      6443
+    ];
+    allowedUDPPorts = [ 8472 ];
+    checkReversePath = "loose";
+  };
+}

--- a/configs/nixos/hosts/hetzner-saas/networking.nix
+++ b/configs/nixos/hosts/hetzner-saas/networking.nix
@@ -5,17 +5,24 @@
   networking.hostName = "hetzner-saas";
 
   systemd.network.enable = true;
+  systemd.network.wait-online.enable = false;
   networking.useDHCP = lib.mkDefault false;
 
   systemd.network.networks."30-wan" = {
-    matchConfig.Name = "en* eth*";
+    matchConfig.Name = "eth0";
+    address = [ "46.62.174.103/32" ];
     networkConfig = {
-      DHCP = "ipv4";
       DNS = [
         "1.1.1.1"
         "8.8.8.8"
       ];
     };
+    routes = [
+      {
+        Gateway = "172.31.1.1";
+        GatewayOnLink = true;
+      }
+    ];
   };
 
   networking.nameservers = lib.mkForce [


### PR DESCRIPTION
## Summary
- Add a separate `hetzner-saas` NixOS host for the MindRoom SaaS K3s deployment instead of reusing `hetzner-matrix`.
- Add matching x86_64 Hetzner hardware, static networking, and ext4 disko configuration.
- Add `hetzner-saas-bootstrap` for first-stage nixos-anywhere rescue deployment.

## Test Plan
- `git diff --check origin/main...HEAD`
- Secret-pattern scan over PR diff returned no matches.
- `cd configs/nixos && nix eval .#nixosConfigurations.hetzner-saas.config.networking.hostName --raw`
- `cd configs/nixos && nix eval .#nixosConfigurations.hetzner-saas.config.services.k3s.enable --json`
- `cd configs/nixos && nix eval .#nixosConfigurations.hetzner-saas.config.system.build.toplevel.drvPath --raw`
- `cd configs/nixos && nix eval .#nixosConfigurations.hetzner-saas-bootstrap.config.system.build.toplevel.drvPath --raw`

## Security
- No plaintext provider tokens, hcloud tokens, Cloudflare keys, OAuth secrets, Supabase secrets, or kubeconfigs are added.