### PR TITLE
Redirect MindRoom apex to SaaS app

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/caddy.nix
+++ b/configs/nixos/hosts/hetzner-matrix/caddy.nix
@@ -2,7 +2,7 @@
 
 let
   constants = import ./constants.nix;
-  inherit (constants) siteDomain cinnyDomain cinnyCurrentPath;
+  inherit (constants) siteDomain appDomain cinnyDomain cinnyCurrentPath;
 in
 {
   systemd.tmpfiles.rules = [
@@ -32,6 +32,10 @@ in
             body "{\"m.homeserver\":{\"base_url\":\"https://${siteDomain}\"}}"
             close
           }
+        }
+
+        handle / {
+          redir https://${appDomain}/ 308
         }
 
         root * /var/www/mindroom

--- a/configs/nixos/hosts/hetzner-matrix/constants.nix
+++ b/configs/nixos/hosts/hetzner-matrix/constants.nix
@@ -1,5 +1,6 @@
 {
   siteDomain = "mindroom.chat";
+  appDomain = "app.mindroom.chat";
   cinnyDomain = "chat.mindroom.chat";
   cinnyCheckoutPath = "/var/www/cinny";
   cinnyPublishedPath = "/var/www/cinny-published";


### PR DESCRIPTION
## Summary
- add `appDomain` to the hetzner-matrix constants
- redirect exact `https://mindroom.chat/` to `https://app.mindroom.chat/` with a 308
- keep Matrix API and Matrix well-known handlers ahead of the redirect

## Verification
- `nix eval --raw '.#nixosConfigurations.hetzner-matrix.config.services.caddy.virtualHosts."mindroom.chat".extraConfig'` renders the exact root redirect after Matrix routes and well-known handlers\n\nThe redirect is intentionally exact-path `/` only, so `/_matrix/*`, `/v1/local-mindroom/*`, and `/.well-known/matrix/*` stay on the Matrix host.