### PR TITLE
Sanitize hetzner-saas hcloud token

### DIFF
--- a/configs/nixos/hosts/hetzner-saas/default.nix
+++ b/configs/nixos/hosts/hetzner-saas/default.nix
@@ -149,8 +149,14 @@ in
         sleep 2
       done
 
+      token="$(tr -cd '[:alnum:]' < "${hcloudTokenFile}")"
+      if [ "''${#token}" -ne 64 ]; then
+        echo "Skipping hcloud Secret creation; sanitized token length is ''${#token}, expected 64"
+        exit 1
+      fi
+
       k3s kubectl -n kube-system create secret generic hcloud \
-        --from-file=token="${hcloudTokenFile}" \
+        --from-literal=token="$token" \
         --dry-run=client \
         -o yaml \
         | k3s kubectl apply -f -


### PR DESCRIPTION
## Summary\n- sanitize the hcloud token file before creating the Kubernetes Secret\n- validate the sanitized token length to avoid broken CSI provisioning\n\n## Tests\n- nix shell nixpkgs#nixos-rebuild -c nixos-rebuild build --flake .#hetzner-saas --target-host root@46.62.174.103 --build-host root@46.62.174.103 --no-reexec