### PR TITLE
Add CORS headers for Matrix well-known

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/caddy.nix
+++ b/configs/nixos/hosts/hetzner-matrix/caddy.nix
@@ -20,6 +20,7 @@ in
 
         handle /.well-known/matrix/server {
           header Content-Type application/json
+          header Access-Control-Allow-Origin "*"
           respond 200 {
             body "{\"m.server\":\"${siteDomain}:443\"}"
             close
@@ -28,6 +29,7 @@ in
 
         handle /.well-known/matrix/client {
           header Content-Type application/json
+          header Access-Control-Allow-Origin "*"
           respond 200 {
             body "{\"m.homeserver\":{\"base_url\":\"https://${siteDomain}\"}}"
             close


### PR DESCRIPTION
## Summary
- add `Access-Control-Allow-Origin: *` to the Matrix server and client well-known responses for `mindroom.chat`
- keep the existing reproducible apex redirect to `appDomain` unchanged

## Validation
- `git diff --check`
- `cd configs/nixos && nix eval --extra-experimental-features "nix-command flakes" .#nixosConfigurations.hetzner-matrix.config.services.caddy.enable`

## Production
- already applied on `mindroom-hetzner` via `nixos-rebuild switch --flake .#hetzner-matrix`