### PR TITLE
Add Lima for standalone VMs and update skhd-zig Homebrew packaging

### DIFF
--- a/configs/nix-darwin/configuration.nix
+++ b/configs/nix-darwin/configuration.nix
@@ -12,6 +12,7 @@
   # Add system packages
   environment.systemPackages = with pkgs; [
     colima # Container runtime for macOS
+    lima # VM manager used by Colima; provides limactl for standalone VMs
     cups # lp command for network printing
     devbox
     docker # Docker CLI

--- a/configs/nix-darwin/homebrew.nix
+++ b/configs/nix-darwin/homebrew.nix
@@ -77,7 +77,6 @@
       "rsync" # File sync tool
       "ruby" # Ruby programming language
       "rustup" # Rust toolchain installer
-      "skhd-zig" # Hotkey daemon
       "ssh-copy-id" # SSH public key installer
       "starship" # Shell prompt
       "superfile" # Modern terminal file manager
@@ -160,6 +159,7 @@
       "rectangle" # Window manager
       "rotki" # Portfolio tracker
       "sabnzbd" # Usenet client
+      "skhd-zig" # Hotkey daemon
       "scroll-reverser" # Scroll direction control
       "selfcontrol" # Website blocker
       "signal" # Secure messenger
@@ -204,7 +204,6 @@
     taps = [
       "gromgit/fuse" # For SSHFS
       "hashicorp/tap" # For Terraform
-      "jackielii/tap" # for skhd-zig
     ];
   };
 }


### PR DESCRIPTION
## Summary
- Add `lima` to the nix-darwin system packages so `limactl` is available for standalone VMs.
- Move `skhd-zig` from the removed Homebrew tap formula to the current cask.
- Remove the obsolete `jackielii/tap` entry from Homebrew taps.

## Testing
- Validated the nix-darwin flake evaluates successfully.
- Confirmed `pkgs.lima` resolves in the current nixpkgs set.
- Reviewed the Homebrew config diff to match the current `skhd-zig` packaging.