### PR TITLE
Harden comin pull deployments

### DIFF
--- a/configs/nixos/common/comin.nix
+++ b/configs/nixos/common/comin.nix
@@ -50,11 +50,15 @@ in
 {
   services.comin = {
     enable = true;
-    remotes = [{
-      name = "origin";
-      url = "https://github.com/basnijholt/dotfiles.git";
-      branches.main.name = "main";
-    }];
+    submodules = true;
+    exporter.listen_address = "127.0.0.1";
+    remotes = [
+      {
+        name = "origin";
+        url = "https://github.com/basnijholt/dotfiles.git";
+        branches.main.name = "main";
+      }
+    ];
     repositorySubdir = "configs/nixos";
     hostname = config.networking.hostName;
   };
@@ -70,6 +74,8 @@ in
       fi
     '';
 
+    # comin can stay systemd-active while a saturated machine prevents it from
+    # making progress. Watch metrics progress instead of only service state.
     comin-watchdog = {
       description = "Check that comin is still polling and reporting healthy deploys";
       wants = [ "comin.service" ];
@@ -87,9 +93,9 @@ in
   systemd.timers.comin-watchdog = lib.mkIf config.services.comin.enable {
     wantedBy = [ "timers.target" ];
     timerConfig = {
-      OnCalendar = "hourly";
+      OnCalendar = "*:0/15";
       Persistent = true;
-      RandomizedDelaySec = "10m";
+      RandomizedDelaySec = "2m";
     };
   };
 }


### PR DESCRIPTION
## Summary

- keep the pull-based `comin` deployment model instead of switching to push-based Colmena
- enable upstream `services.comin.submodules` so deployments fetch repository submodules declaratively
- bind the comin metrics exporter to localhost explicitly
- run the existing metrics-progress watchdog every 15 minutes instead of hourly

## Rationale

Colmena requires a remote activation path with passwordless sudo, root SSH, or an equivalent privilege escalation mechanism.
That is not the security model I want for these hosts.

The comin issue we hit was operational reliability: it could remain systemd-active while not making progress under heavy NAS IO.
The watchdog checks comin's documented Prometheus metrics, especially `comin_fetch_count`, so that failure mode becomes visible.

## Validation

- `cd configs/nixos && nix eval --json .#nixosConfigurations.nas.config.services.comin.submodules`
- `cd configs/nixos && nix eval --raw .#nixosConfigurations.nas.config.services.comin.exporter.listen_address`
- `cd configs/nixos && nix eval --raw .#nixosConfigurations.nas.config.systemd.timers.comin-watchdog.timerConfig.OnCalendar`
- `cd configs/nixos && nix eval --json .#nixosConfigurations.nas.config.systemd.services.comin-watchdog.unitConfig.OnFailure`
- `cd configs/nixos && nix eval --raw .#nixosConfigurations.docker-lxc.config.system.build.toplevel.drvPath`
- `cd configs/nixos && nix eval --raw .#nixosConfigurations.nas.config.system.build.toplevel.drvPath`
- `cd configs/nixos && nix build .#nixosConfigurations.docker-lxc.config.system.build.toplevel --no-link`
