### PR TITLE
Avoid comin private submodule fetch

### DIFF
--- a/configs/nixos/common/comin.nix
+++ b/configs/nixos/common/comin.nix
@@ -50,8 +50,10 @@ in
 {
   services.comin = {
     enable = true;
-    submodules = true;
     exporter.listen_address = "127.0.0.1";
+    # Do not enable services.comin.submodules here. That makes Nix evaluate the
+    # flake with ?submodules=1, which tries to fetch private git@github.com
+    # submodules from comin's root context and fails without a deploy SSH key.
     remotes = [
       {
         name = "origin";


### PR DESCRIPTION
## Summary

- keep the comin exporter binding and 15-minute watchdog from #65
- remove `services.comin.submodules = true`
- document why comin should not evaluate this flake with `?submodules=1`

## Why

After #65 deployed on `nix-cache`, comin restarted with `submodules=true` and immediately failed the next evaluation because Nix tried to fetch the private `git@github.com:basnijholt/dotfiles-secrets.git` submodule from comin's root context:

```text
git@github.com: Permission denied (publickey)
error: Failed to fetch git repository 'ssh://git@github.com/basnijholt/dotfiles-secrets.git'
```

That means upstream comin submodule support is not compatible with this repo's private SSH submodule setup unless we also provision deploy SSH credentials for comin, which is not the security model we want.

## Validation

- `cd configs/nixos && nix eval --json .#nixosConfigurations.nix-cache.config.services.comin.submodules` -> `false`
- `cd configs/nixos && nix eval --raw .#nixosConfigurations.nix-cache.config.services.comin.exporter.listen_address` -> `127.0.0.1`
- `cd configs/nixos && nix eval --raw .#nixosConfigurations.nix-cache.config.systemd.timers.comin-watchdog.timerConfig.OnCalendar` -> `*:0/15`
- `cd configs/nixos && nix build .#nixosConfigurations.docker-lxc.config.system.build.toplevel --no-link`
