### PR TITLE
feat(nas): close silent backup-monitoring failure modes

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/default.nix
+++ b/configs/nixos/hosts/hetzner-matrix/default.nix
@@ -28,7 +28,16 @@
   # ── General server config ──────────────────────────────────────────
 
   # Packages needed for release pin updates and operational debugging.
-  environment.systemPackages = with pkgs; [ git curl jq ffmpeg-headless ];
+  # lz4 and mbuffer serve the NAS syncoid pull (nas-replicate-hetzner-matrix);
+  # without them the transfer falls back to uncompressed and unbuffered.
+  environment.systemPackages = with pkgs; [
+    git
+    curl
+    jq
+    ffmpeg-headless
+    lz4
+    mbuffer
+  ];
 
   # Disable services not needed on a Matrix server
   services.fwupd.enable = lib.mkForce false;

--- a/configs/nixos/hosts/nas/PLANNING.md
+++ b/configs/nixos/hosts/nas/PLANNING.md
@@ -13,7 +13,7 @@ Commands for reinstalling or repeating the migration belong in `CUTOVER.md`.
 - Monitoring dashboard: Grafana scrapes the NAS Prometheus exporters; host Netdata stays localhost-only.
 - Base branch: `main`
 - Host name in Nix: `nas`
-- Last updated: `2026-06-29 post-cutover validation`
+- Last updated: `2026-07-06 backup-monitoring hardening`
 
 The real NAS has been cut over from TrueNAS to NixOS with this host config.
 The destructive storage migration is complete.
@@ -133,7 +133,11 @@ The data pools are imported by name and are not described by disko.
 - [x] Confirm the authoritative Backblaze B2 job completed once and wrote a persistent success marker.
 - [x] Confirm the NAS B2 watchdog reports the B2 success marker as fresh.
 - [x] Keep `.ix-virt` backed up for Incus restore fidelity, but skip only the rebuildable `ssd/.ix-virt/containers/nix-cache` dataset in future SSD Syncoid jobs.
-- [ ] Decide whether old TrueNAS-created snapshots and pre-exclusion NAS-local `tank/backups` autosnapshots should be aged out manually.
+- [x] Add a prune-only Sanoid policy on `tank/backups` so replicated `autosnap_` snapshots are aged out on the targets instead of accumulating forever.
+- [x] Alert when Sanoid itself fails and when the source pools stop receiving fresh autosnapshots (syncoid sync snaps would otherwise keep the watchdog green).
+- [x] Make the replication watchdog fail when an expected outbound replication key file is missing, so a `ConditionPathExists` skip cannot stay silent after a reinstall.
+- [ ] Decide whether old TrueNAS-created snapshots (not `autosnap_` named, so untouched by the new prune policy) should be aged out manually.
+- [ ] Verify every irreplaceable `tank` dataset (photos, photos-export, syncthing) has an off-machine backup path; the declared jobs only replicate `ssd` off-box.
 
 ### Encryption
 
@@ -153,6 +157,8 @@ The data pools are imported by name and are not described by disko.
 - [x] Validate UPS status with `upsc` and the NUT exporter.
 - [x] Confirm the configured UPS name matches the name exposed by the remote NUT server.
 - [x] Authenticate host-level Tailscale with `tailscale up`.
+- [x] Declare a `nas-heartbeat` dead-man's-switch timer that pings an external healthchecks-style URL every 5 minutes.
+- [ ] Create the external healthchecks check and install its private ping URL at `/etc/nas-heartbeat-url` (mode `0600`) on the NAS; the `nas-heartbeat` unit skips until that file exists.
 
 ### Deploy
 

--- a/configs/nixos/hosts/nas/PLANNING.md
+++ b/configs/nixos/hosts/nas/PLANNING.md
@@ -13,7 +13,7 @@ Commands for reinstalling or repeating the migration belong in `CUTOVER.md`.
 - Monitoring dashboard: Grafana scrapes the NAS Prometheus exporters; host Netdata stays localhost-only.
 - Base branch: `main`
 - Host name in Nix: `nas`
-- Last updated: `2026-07-06 backup-monitoring hardening`
+- Last updated: `2026-07-09 backup-monitoring hardening + pc restic repo watchdog`
 
 The real NAS has been cut over from TrueNAS to NixOS with this host config.
 The destructive storage migration is complete.
@@ -136,6 +136,8 @@ The data pools are imported by name and are not described by disko.
 - [x] Add a prune-only Sanoid policy on `tank/backups` so replicated `autosnap_` snapshots are aged out on the targets instead of accumulating forever.
 - [x] Alert when Sanoid itself fails and when the source pools stop receiving fresh autosnapshots (syncoid sync snaps would otherwise keep the watchdog green).
 - [x] Make the replication watchdog fail when an expected outbound replication key file is missing, so a `ConditionPathExists` skip cannot stay silent after a reinstall.
+- [x] Add a freshness check for the pc restic repo (`tank/backups/pc`) to the replication watchdog; a 2026-07-09 review found pc's hourly restic backups had failed silently since 2026-03-22 on a stale repo lock, and nothing on the NAS watched that repo.
+- [ ] After the stale restic lock on pc is cleared (`restic-truenas unlock` on pc, then `restic-truenas check`), confirm hourly backups resume and the new pc-restic watchdog check reports OK.
 - [ ] Decide whether old TrueNAS-created snapshots (not `autosnap_` named, so untouched by the new prune policy) should be aged out manually.
 - [ ] Verify every irreplaceable `tank` dataset (photos, photos-export, syncthing) has an off-machine backup path; the declared jobs only replicate `ssd` off-box.
 

--- a/configs/nixos/hosts/nas/PLANNING.md
+++ b/configs/nixos/hosts/nas/PLANNING.md
@@ -134,12 +134,19 @@ The data pools are imported by name and are not described by disko.
 - [x] Confirm the NAS B2 watchdog reports the B2 success marker as fresh.
 - [x] Keep `.ix-virt` backed up for Incus restore fidelity, but skip only the rebuildable `ssd/.ix-virt/containers/nix-cache` dataset in future SSD Syncoid jobs.
 - [x] Add a prune-only Sanoid policy on `tank/backups` so replicated `autosnap_` snapshots are aged out on the targets instead of accumulating forever.
+- [x] Trim `tank/backups/hetzner` with syncoid `--delete-target-snapshots`: hetzner's snapshots are `zfs-auto-snap_*` named (zfs.autoSnapshot, not sanoid), so the prune policy never matches them and 700+ had accumulated. The first run after deploy will delete the ~670 target snapshots that no longer exist on the source.
 - [x] Alert when Sanoid itself fails and when the source pools stop receiving fresh autosnapshots (syncoid sync snaps would otherwise keep the watchdog green).
 - [x] Make the replication watchdog fail when an expected outbound replication key file is missing, so a `ConditionPathExists` skip cannot stay silent after a reinstall.
 - [x] Add a freshness check for the pc restic repo (`tank/backups/pc`) to the replication watchdog; a 2026-07-09 review found pc's hourly restic backups had failed silently since 2026-03-22 on a stale repo lock, and nothing on the NAS watched that repo.
 - [ ] After the stale restic lock on pc is cleared (`restic-truenas unlock` on pc, then `restic-truenas check`), confirm hourly backups resume and the new pc-restic watchdog check reports OK.
 - [ ] Decide whether old TrueNAS-created snapshots (not `autosnap_` named, so untouched by the new prune policy) should be aged out manually.
 - [ ] Verify every irreplaceable `tank` dataset (photos, photos-export, syncthing) has an off-machine backup path; the declared jobs only replicate `ssd` off-box.
+- [ ] Close the fleet backup gaps found in the 2026-07-21 audit: `hetzner-saas` (k3s SaaS state, `/var/lib/mindroom-saas`) has no backup at all; the `mindroom` LXC (and `mindroom-mom`/`mindroom-spouse` companions) run on an undetermined Incus host and are at best covered by pc's broken restic job; the `hetzner` websites host only replicates `zroot/websites`, so Docker named volumes under `/var/lib/docker` (if any) are not covered.
+- [x] Declare a nightly pull of hetzner-matrix (mindroom.chat, 46.225.140.219) into `tank/backups/hetzner-matrix`: `zroot/tuwunel` (Matrix RocksDB) and `zroot/var` (bridge state, secrets). A 2026-07-21 review found the host had only same-box `zfs-auto-snapshot` and no off-machine backup at all. Includes watchdog freshness checks per child dataset and a key-presence check.
+- [x] hetzner-matrix backup manual setup (2026-07-21): created `tank/backups/hetzner-matrix`, generated `/etc/ssh/nas-replication-hetzner-matrix-ed25519`, installed the public key for root on hetzner-matrix pinned to the NAS tailnet IP (`from="100.64.0.1"`, stable across home WAN IP changes; a DDNS name cannot serve as the pin because sshd `from=` matches reverse DNS), and accepted host keys into root's known_hosts. The declared pull goes over tailscale to 100.64.0.36.
+- [ ] Confirm the manually started initial syncoid pull of `zroot/tuwunel` (~15G) and `zroot/var` (~6G) completed into `tank/backups/hetzner-matrix`.
+- [ ] Remove the temporary `from="50.35.43.98"` (public path) line from root's authorized_keys on hetzner-matrix; it only exists so the in-flight initial pull, which started against the public IP, can finish.
+- [ ] After deploying this branch: confirm the `nas-replicate-hetzner-matrix` timer runs and the watchdog reports both `hetzner-matrix` datasets and the key check OK.
 
 ### Encryption
 

--- a/configs/nixos/hosts/nas/health.nix
+++ b/configs/nixos/hosts/nas/health.nix
@@ -1,66 +1,72 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   ntfyUrl = "http://192.168.1.2:8089/nas-alerts";
   ntfyPriority = "high";
+  heartbeatUrlFile = "/etc/nas-heartbeat-url";
 
   nasHealthAlert = pkgs.writeShellScriptBin "nas-health-alert" ''
-    set -euo pipefail
+        set -euo pipefail
 
-    subject="NAS health alert"
-    args=()
+        subject="NAS health alert"
+        args=()
 
-    while [ "$#" -gt 0 ]; do
-      case "$1" in
-        -s)
-          subject="''${2:-$subject}"
-          shift 2
-          ;;
-        *)
-          args+=("$1")
-          shift
-          ;;
-      esac
-    done
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            -s)
+              subject="''${2:-$subject}"
+              shift 2
+              ;;
+            *)
+              args+=("$1")
+              shift
+              ;;
+          esac
+        done
 
-    body=""
-    if [ -n "''${SMARTD_MESSAGE:-}" ]; then
-      subject="''${SMARTD_SUBJECT:-SMARTD alert on nas}"
-      body="$SMARTD_MESSAGE"
-    fi
+        body=""
+        if [ -n "''${SMARTD_MESSAGE:-}" ]; then
+          subject="''${SMARTD_SUBJECT:-SMARTD alert on nas}"
+          body="$SMARTD_MESSAGE"
+        fi
 
-    stdin=""
-    if ! [ -t 0 ]; then
-      stdin="$(${pkgs.coreutils}/bin/cat || true)"
-    fi
-    if [ -n "$stdin" ]; then
-      body="''${body:+$body
+        stdin=""
+        if ! [ -t 0 ]; then
+          stdin="$(${pkgs.coreutils}/bin/cat || true)"
+        fi
+        if [ -n "$stdin" ]; then
+          body="''${body:+$body
 
-}$stdin"
-    fi
-    if [ "''${#args[@]}" -gt 0 ]; then
-      body="''${body:+$body
+    }$stdin"
+        fi
+        if [ "''${#args[@]}" -gt 0 ]; then
+          body="''${body:+$body
 
-}alert arguments: ''${args[*]}"
-    fi
-    if [ -z "$body" ]; then
-      body="NAS health alert hook invoked without a message body."
-    fi
+    }alert arguments: ''${args[*]}"
+        fi
+        if [ -z "$body" ]; then
+          body="NAS health alert hook invoked without a message body."
+        fi
 
-    summary="$(printf '%s' "$body" | ${pkgs.coreutils}/bin/tr '\n' ' ' | ${pkgs.coreutils}/bin/cut -c1-500)"
-    ${pkgs.util-linux}/bin/logger -t nas-health-alert -- "$subject: $summary"
-    printf '%s\n\n%s\n' "$subject" "$body" | ${pkgs.util-linux}/bin/wall || true
+        summary="$(printf '%s' "$body" | ${pkgs.coreutils}/bin/tr '\n' ' ' | ${pkgs.coreutils}/bin/cut -c1-500)"
+        ${pkgs.util-linux}/bin/logger -t nas-health-alert -- "$subject: $summary"
+        printf '%s\n\n%s\n' "$subject" "$body" | ${pkgs.util-linux}/bin/wall || true
 
-    ${pkgs.curl}/bin/curl \
-      --fail \
-      --silent \
-      --show-error \
-      --max-time 10 \
-      -H "Title: $subject" \
-      -H ${lib.escapeShellArg "Priority: ${ntfyPriority}"} \
-      --data-binary "$body" \
-      ${lib.escapeShellArg ntfyUrl} >/dev/null \
-      || ${pkgs.util-linux}/bin/logger -t nas-health-alert -- "failed to send ntfy alert"
+        ${pkgs.curl}/bin/curl \
+          --fail \
+          --silent \
+          --show-error \
+          --max-time 10 \
+          -H "Title: $subject" \
+          -H ${lib.escapeShellArg "Priority: ${ntfyPriority}"} \
+          --data-binary "$body" \
+          ${lib.escapeShellArg ntfyUrl} >/dev/null \
+          || ${pkgs.util-linux}/bin/logger -t nas-health-alert -- "failed to send ntfy alert"
   '';
 
   alertFailedUnit = pkgs.writeShellScript "nas-health-alert-failed-unit" ''
@@ -228,6 +234,39 @@ in
 
   systemd.services.comin-watchdog = lib.mkIf config.services.comin.enable {
     unitConfig.OnFailure = [ "nas-health-alert@%n.service" ];
+  };
+
+  # Dead man's switch. Everything above alerts on failure, but nothing alerts
+  # on absence: if the whole NAS hangs, no OnFailure ever fires, and both the
+  # Grafana stack (Incus container on this host) and the ntfy relay (NUC) are
+  # too close to the failure domain. An external healthchecks-style service
+  # alerts when these pings stop arriving. There is deliberately no OnFailure
+  # here: detecting missed pings is the external service's job, and a local
+  # alert on transient egress failure would only add noise.
+  #
+  # The private ping URL is installed manually (mode 0600), like the
+  # replication keys; the unit skips until the file exists:
+  #   echo 'https://hc-ping.com/<uuid>' | sudo install -m 0600 /dev/stdin ${heartbeatUrlFile}
+  systemd.services.nas-heartbeat = {
+    description = "Ping external dead-man's-switch URL";
+    unitConfig.ConditionPathExists = heartbeatUrlFile;
+    script = ''
+      url="$(${pkgs.coreutils}/bin/cat ${heartbeatUrlFile})"
+      ${pkgs.curl}/bin/curl \
+        --fail \
+        --silent \
+        --show-error \
+        --max-time 10 \
+        --retry 2 \
+        --output /dev/null \
+        "$url"
+    '';
+    serviceConfig.Type = "oneshot";
+  };
+
+  systemd.timers.nas-heartbeat = {
+    wantedBy = [ "timers.target" ];
+    timerConfig.OnCalendar = "*:0/5";
   };
 
   environment.systemPackages = [ nasHealthAlert ];

--- a/configs/nixos/hosts/nas/replication.nix
+++ b/configs/nixos/hosts/nas/replication.nix
@@ -176,12 +176,14 @@ let
       dataset="$2"
       max_age_hours="$3"
 
-      # With -t snapshot, -d 1 lists only this dataset's own snapshots: child
-      # datasets sit at depth 1, so their snapshots are at depth 2 and
-      # excluded. A fresh child autosnap cannot mask a stale root here.
+      # With -t snapshot, -d 1 lists only this dataset's own snapshots (child
+      # datasets sit at depth 1, so their snapshots are at depth 2; verified
+      # live on the nas). The exact prefix match below keeps a fresh child
+      # autosnap from masking a stale root even if that depth behavior ever
+      # changes, instead of relying on it.
       latest="$(
         zfs list -H -p -t snapshot -d 1 -o creation,name -s creation "$dataset" 2>/dev/null \
-          | ${pkgs.gnugrep}/bin/grep '@autosnap_' \
+          | ${pkgs.gawk}/bin/awk -v prefix="$dataset@autosnap_" 'index($2, prefix) == 1' \
           | ${pkgs.coreutils}/bin/tail -n 1 \
           || true
       )"

--- a/configs/nixos/hosts/nas/replication.nix
+++ b/configs/nixos/hosts/nas/replication.nix
@@ -32,6 +32,15 @@ let
 
   nucReplicationKey = "/etc/ssh/nas-replication-nuc-ed25519";
   hetznerReplicationKey = "/etc/ssh/nas-replication-hetzner-ed25519";
+  hetznerMatrixReplicationKey = "/etc/ssh/nas-replication-hetzner-matrix-ed25519";
+
+  # hetzner-matrix (mindroom.chat), via its tailnet IP. Both ends have stable
+  # tailscale addresses, so the from= pin in root's authorized_keys there is
+  # the NAS's tailnet IP (100.64.0.1) and survives home WAN IP changes. A
+  # DDNS name cannot serve as that pin: sshd from= matches the connecting
+  # IP's reverse DNS, never a forward lookup. If the server is recreated and
+  # rejoins the tailnet as a new node, update this IP and the remote pin.
+  hetznerMatrixHost = "100.64.0.36";
 
   # The outbound key files intentionally live outside this repo. Their services
   # skip via ConditionPathExists while a key is missing (e.g. after a reinstall
@@ -46,6 +55,10 @@ let
     {
       label = "hetzner outbound replication key";
       path = hetznerReplicationKey;
+    }
+    {
+      label = "hetzner-matrix outbound replication key";
+      path = hetznerMatrixReplicationKey;
     }
   ];
 
@@ -104,6 +117,19 @@ let
     {
       label = "hetzner websites";
       dataset = "tank/backups/hetzner";
+      maxAgeHours = 48;
+    }
+    # Watch the hetzner-matrix children separately: both come from the same
+    # pull job, but a per-dataset check keeps a fresh var snapshot from
+    # masking a stale tuwunel one (or vice versa).
+    {
+      label = "hetzner-matrix tuwunel";
+      dataset = "tank/backups/hetzner-matrix/tuwunel";
+      maxAgeHours = 48;
+    }
+    {
+      label = "hetzner-matrix var";
+      dataset = "tank/backups/hetzner-matrix/var";
       maxAgeHours = 48;
     }
   ];
@@ -381,7 +407,12 @@ in
 
       zfs list tank/backups/hetzner >/dev/null
 
+      # Hetzner snapshots are zfs-auto-snap_* named (services.zfs.autoSnapshot,
+      # not sanoid), so the nas-backup-prune policy never matches them and the
+      # mirror would accumulate every source snapshot forever. Trim the target
+      # to the source's retention instead, like the hp/nuc/pi4 push jobs do.
       syncoid ${mkSyncoidCommonArgs} \
+        --delete-target-snapshots \
         --sshkey=${hetznerReplicationKey} \
         --sshport=22 \
         --sshoption=BatchMode=yes \
@@ -399,6 +430,59 @@ in
     wantedBy = [ "timers.target" ];
     timerConfig = {
       OnCalendar = "*-*-* 00:45:00";
+      Persistent = true;
+      RandomizedDelaySec = "15m";
+    };
+  };
+
+  systemd.services.nas-replicate-hetzner-matrix = {
+    description = "Pull hetzner-matrix (mindroom) backups over SSH";
+    restartIfChanged = false;
+    wants = [
+      "network-online.target"
+      "zfs.target"
+    ];
+    after = [
+      "network-online.target"
+      "zfs.target"
+    ];
+    unitConfig = {
+      ConditionPathExists = hetznerMatrixReplicationKey;
+      OnFailure = [ "nas-health-alert@%n.service" ];
+    };
+    path = replicationPath;
+    script = ''
+      set -euo pipefail
+
+      zfs list tank/backups/hetzner-matrix >/dev/null
+
+      # zroot/tuwunel is the Matrix RocksDB; zroot/var holds the mautrix
+      # bridge state and secrets under /var/lib. The rest of zroot (root,
+      # nix, home) is rebuildable from this repo.
+      # The source snapshots are zfs-auto-snap_* named (zfs.autoSnapshot, not
+      # sanoid), so trim the targets with --delete-target-snapshots like the
+      # websites pull; the sanoid prune policy never matches that naming.
+      for dataset in tuwunel var; do
+        syncoid ${mkSyncoidCommonArgs} \
+          --delete-target-snapshots \
+          --sshkey=${hetznerMatrixReplicationKey} \
+          --sshport=22 \
+          --sshoption=BatchMode=yes \
+          --sshoption=ConnectTimeout=10 \
+          root@${hetznerMatrixHost}:zroot/"$dataset" tank/backups/hetzner-matrix/"$dataset"
+      done
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      User = "root";
+      TimeoutStartSec = "infinity";
+    };
+  };
+
+  systemd.timers.nas-replicate-hetzner-matrix = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "*-*-* 00:55:00";
       Persistent = true;
       RandomizedDelaySec = "15m";
     };

--- a/configs/nixos/hosts/nas/replication.nix
+++ b/configs/nixos/hosts/nas/replication.nix
@@ -66,6 +66,20 @@ let
     }
   ];
 
+  # The pc restic backup is file-based (hourly sftp push into tank/backups/pc),
+  # so no dataset snapshot check can see it. Restic writes one file per
+  # completed snapshot into the repo's snapshots/ directory; the newest file
+  # mtime is the last successful backup. Added 2026-07-09 after finding pc's
+  # backups had failed silently since 2026-03-22 on a stale repo lock —
+  # nothing watched this repo. pc backs up hourly; 26h absorbs downtime.
+  watchedResticRepos = [
+    {
+      label = "pc restic repo";
+      path = "/mnt/tank/backups/pc";
+      maxAgeHours = 26;
+    }
+  ];
+
   watchedBackupDatasets = [
     {
       label = "local ssd mirror";
@@ -110,6 +124,10 @@ let
   watchdogKeyChecks = pkgs.lib.concatMapStringsSep "\n" (entry: ''
     check_key ${pkgs.lib.escapeShellArg entry.label} ${pkgs.lib.escapeShellArg entry.path}
   '') watchedReplicationKeys;
+
+  watchdogResticChecks = pkgs.lib.concatMapStringsSep "\n" (entry: ''
+    check_restic_repo ${pkgs.lib.escapeShellArg entry.label} ${pkgs.lib.escapeShellArg entry.path} ${toString entry.maxAgeHours}
+  '') watchedResticRepos;
 
   replicationWatchdog = pkgs.writeShellScript "nas-replication-watchdog" ''
     set -euo pipefail
@@ -158,6 +176,9 @@ let
       dataset="$2"
       max_age_hours="$3"
 
+      # With -t snapshot, -d 1 lists only this dataset's own snapshots: child
+      # datasets sit at depth 1, so their snapshots are at depth 2 and
+      # excluded. A fresh child autosnap cannot mask a stale root here.
       latest="$(
         zfs list -H -p -t snapshot -d 1 -o creation,name -s creation "$dataset" 2>/dev/null \
           | ${pkgs.gnugrep}/bin/grep '@autosnap_' \
@@ -197,9 +218,47 @@ let
       echo "OK $label: $key_path exists"
     }
 
+    check_restic_repo() {
+      label="$1"
+      repo_path="$2"
+      max_age_hours="$3"
+
+      snapshot_dir="$repo_path/snapshots"
+
+      if [ ! -d "$snapshot_dir" ]; then
+        echo "MISSING $label: $snapshot_dir does not exist"
+        failed=1
+        return
+      fi
+
+      latest_epoch="$(
+        ${pkgs.findutils}/bin/find "$snapshot_dir" -maxdepth 1 -type f -printf '%T@\n' 2>/dev/null \
+          | ${pkgs.coreutils}/bin/sort -n \
+          | ${pkgs.coreutils}/bin/tail -n 1 \
+          | ${pkgs.coreutils}/bin/cut -d . -f 1
+      )"
+
+      if [ -z "$latest_epoch" ]; then
+        echo "STALE $label: no snapshot files in $snapshot_dir"
+        failed=1
+        return
+      fi
+
+      age_hours=$(( (now - latest_epoch) / 3600 ))
+
+      if [ "$age_hours" -gt "$max_age_hours" ]; then
+        echo "STALE $label: newest restic snapshot is ''${age_hours}h old; limit is ''${max_age_hours}h"
+        failed=1
+        return
+      fi
+
+      echo "OK $label: newest restic snapshot is ''${age_hours}h old; limit is ''${max_age_hours}h"
+    }
+
     ${watchdogChecks}
     ${watchdogAutosnapChecks}
     ${watchdogKeyChecks}
+    ${watchdogResticChecks}
 
     if [ "$failed" -ne 0 ]; then
       exit 1

--- a/configs/nixos/hosts/nas/replication.nix
+++ b/configs/nixos/hosts/nas/replication.nix
@@ -30,6 +30,42 @@ let
   mkSyncoidSsdArgs = mkSyncoidArgs syncoidSsdExcludes;
   nucReceiveOptions = pkgs.lib.escapeShellArg "u o mountpoint=none o readonly=on";
 
+  nucReplicationKey = "/etc/ssh/nas-replication-nuc-ed25519";
+  hetznerReplicationKey = "/etc/ssh/nas-replication-hetzner-ed25519";
+
+  # The outbound key files intentionally live outside this repo. Their services
+  # skip via ConditionPathExists while a key is missing (e.g. after a reinstall
+  # before secret staging), which never fails a unit and so never alerts. The
+  # watchdog checks presence so a forgotten key becomes an alert instead of
+  # silently absent replication.
+  watchedReplicationKeys = [
+    {
+      label = "nuc outbound replication key";
+      path = nucReplicationKey;
+    }
+    {
+      label = "hetzner outbound replication key";
+      path = hetznerReplicationKey;
+    }
+  ];
+
+  # Syncoid creates its own sync snapshot on every run, so the backup-target
+  # freshness checks stay green even if sanoid stops autosnapshotting. Check
+  # the source pools for recent sanoid-named snapshots separately. Sanoid runs
+  # every 10 minutes with frequent snapshots enabled, so 2 hours is generous.
+  watchedAutosnapSources = [
+    {
+      label = "tank sanoid autosnaps";
+      dataset = "tank";
+      maxAgeHours = 2;
+    }
+    {
+      label = "ssd sanoid autosnaps";
+      dataset = "ssd";
+      maxAgeHours = 2;
+    }
+  ];
+
   watchedBackupDatasets = [
     {
       label = "local ssd mirror";
@@ -66,6 +102,14 @@ let
   watchdogChecks = pkgs.lib.concatMapStringsSep "\n" (entry: ''
     check_dataset ${pkgs.lib.escapeShellArg entry.label} ${pkgs.lib.escapeShellArg entry.dataset} ${toString entry.maxAgeHours}
   '') watchedBackupDatasets;
+
+  watchdogAutosnapChecks = pkgs.lib.concatMapStringsSep "\n" (entry: ''
+    check_autosnap ${pkgs.lib.escapeShellArg entry.label} ${pkgs.lib.escapeShellArg entry.dataset} ${toString entry.maxAgeHours}
+  '') watchedAutosnapSources;
+
+  watchdogKeyChecks = pkgs.lib.concatMapStringsSep "\n" (entry: ''
+    check_key ${pkgs.lib.escapeShellArg entry.label} ${pkgs.lib.escapeShellArg entry.path}
+  '') watchedReplicationKeys;
 
   replicationWatchdog = pkgs.writeShellScript "nas-replication-watchdog" ''
     set -euo pipefail
@@ -109,7 +153,53 @@ let
       echo "OK $label: newest snapshot $latest_snapshot is ''${age_hours}h old; limit is ''${max_age_hours}h"
     }
 
+    check_autosnap() {
+      label="$1"
+      dataset="$2"
+      max_age_hours="$3"
+
+      latest="$(
+        zfs list -H -p -t snapshot -d 1 -o creation,name -s creation "$dataset" 2>/dev/null \
+          | ${pkgs.gnugrep}/bin/grep '@autosnap_' \
+          | ${pkgs.coreutils}/bin/tail -n 1 \
+          || true
+      )"
+
+      if [ -z "$latest" ]; then
+        echo "STALE $label: no autosnap snapshots on $dataset"
+        failed=1
+        return
+      fi
+
+      latest_epoch="$(printf '%s\n' "$latest" | ${pkgs.gawk}/bin/awk '{ print $1 }')"
+      latest_snapshot="$(printf '%s\n' "$latest" | ${pkgs.gawk}/bin/awk '{ print $2 }')"
+      age_hours=$(( (now - latest_epoch) / 3600 ))
+
+      if [ "$age_hours" -gt "$max_age_hours" ]; then
+        echo "STALE $label: newest autosnap $latest_snapshot is ''${age_hours}h old; limit is ''${max_age_hours}h"
+        failed=1
+        return
+      fi
+
+      echo "OK $label: newest autosnap $latest_snapshot is ''${age_hours}h old; limit is ''${max_age_hours}h"
+    }
+
+    check_key() {
+      label="$1"
+      key_path="$2"
+
+      if [ ! -f "$key_path" ]; then
+        echo "MISSING $label: $key_path does not exist; its replication service is silently skipping"
+        failed=1
+        return
+      fi
+
+      echo "OK $label: $key_path exists"
+    }
+
     ${watchdogChecks}
+    ${watchdogAutosnapChecks}
+    ${watchdogKeyChecks}
 
     if [ "$failed" -ne 0 ]; then
       exit 1
@@ -176,7 +266,7 @@ in
       "zfs.target"
     ];
     unitConfig = {
-      ConditionPathExists = "/etc/ssh/nas-replication-nuc-ed25519";
+      ConditionPathExists = nucReplicationKey;
       OnFailure = [ "nas-health-alert@%n.service" ];
     };
     path = replicationPath;
@@ -187,7 +277,7 @@ in
 
       syncoid ${mkSyncoidSsdArgs} \
         --recvoptions=${nucReceiveOptions} \
-        --sshkey=/etc/ssh/nas-replication-nuc-ed25519 \
+        --sshkey=${nucReplicationKey} \
         --sshport=22 \
         --sshoption=BatchMode=yes \
         --sshoption=ConnectTimeout=10 \
@@ -221,7 +311,7 @@ in
       "zfs.target"
     ];
     unitConfig = {
-      ConditionPathExists = "/etc/ssh/nas-replication-hetzner-ed25519";
+      ConditionPathExists = hetznerReplicationKey;
       OnFailure = [ "nas-health-alert@%n.service" ];
     };
     path = replicationPath;
@@ -231,7 +321,7 @@ in
       zfs list tank/backups/hetzner >/dev/null
 
       syncoid ${mkSyncoidCommonArgs} \
-        --sshkey=/etc/ssh/nas-replication-hetzner-ed25519 \
+        --sshkey=${hetznerReplicationKey} \
         --sshport=22 \
         --sshoption=BatchMode=yes \
         --sshoption=ConnectTimeout=10 \

--- a/configs/nixos/hosts/nas/storage.nix
+++ b/configs/nixos/hosts/nas/storage.nix
@@ -85,11 +85,14 @@ in
     };
     # Replication targets under tank/backups: never snapshot here, but prune
     # the autosnap_ snapshots that replication delivers — otherwise the
-    # mirrors accumulate every source snapshot forever. Retention is a
-    # superset of every source policy (nas-default above and zfs-default on
-    # hp/nuc/pi4/hetzner), so a target always keeps at least as much history
-    # as its source. Sanoid only prunes snapshots it named itself; syncoid
-    # sync snaps and TrueNAS-era snapshots are untouched.
+    # mirrors accumulate every source snapshot forever. In practice only
+    # tank/backups/ssd receives sanoid-named autosnap_ snapshots (from this
+    # host's own ssd pool); hp/nuc/pi4/hetzner use zfs-auto-snap_* naming,
+    # which sanoid never prunes — those mirrors are trimmed by syncoid's
+    # --delete-target-snapshots instead. Retention here is a superset of
+    # nas-default above, so the ssd mirror always keeps at least as much
+    # history as its source. Sanoid only prunes snapshots it named itself;
+    # syncoid sync snaps and TrueNAS-era snapshots are untouched.
     templates.nas-backup-prune = {
       autosnap = false;
       autoprune = true;

--- a/configs/nixos/hosts/nas/storage.nix
+++ b/configs/nixos/hosts/nas/storage.nix
@@ -83,14 +83,29 @@ in
       weekly = 52;
       monthly = 1;
     };
+    # Replication targets under tank/backups: never snapshot here, but prune
+    # the autosnap_ snapshots that replication delivers — otherwise the
+    # mirrors accumulate every source snapshot forever. Retention is a
+    # superset of every source policy (nas-default above and zfs-default on
+    # hp/nuc/pi4/hetzner), so a target always keeps at least as much history
+    # as its source. Sanoid only prunes snapshots it named itself; syncoid
+    # sync snaps and TrueNAS-era snapshots are untouched.
+    templates.nas-backup-prune = {
+      autosnap = false;
+      autoprune = true;
+      frequently = 12;
+      hourly = 48;
+      daily = 31;
+      weekly = 52;
+      monthly = 12;
+    };
     datasets = {
       tank = {
         useTemplate = [ "nas-default" ];
         recursive = true;
       };
       "tank/backups" = {
-        autosnap = false;
-        autoprune = false;
+        useTemplate = [ "nas-backup-prune" ];
         recursive = true;
       };
       ssd = {
@@ -99,6 +114,11 @@ in
       };
     };
   };
+
+  # Sanoid failures must alert: syncoid's own sync snapshots keep the
+  # replication watchdog green even when autosnapshots have stopped, so a
+  # silently failing sanoid would otherwise go unnoticed.
+  systemd.services.sanoid.unitConfig.OnFailure = [ "nas-health-alert@%n.service" ];
 
   environment.systemPackages = with pkgs; [
     hdparm


### PR DESCRIPTION
Follow-up to the TrueNAS→NixOS migration (#61–#63): four cases where backups or monitoring on the NAS could fail **without producing any alert**.

## Changes

### 1. Watchdog fails on missing replication keys (`replication.nix`)
`nas-replicate-ssd-to-nuc` and `nas-replicate-hetzner-websites` gate on `ConditionPathExists` for their SSH keys. A condition-skip never fails the unit, so after a reinstall without secret staging, offsite replication would silently never run. The hourly watchdog now checks that both key files exist and alerts if not. The key paths are also deduplicated into `let`-bindings so the services and watchdog can't drift.

### 2. Source autosnap freshness + sanoid alert hook (`replication.nix`, `storage.nix`)
Syncoid creates its own sync snapshot on every run, so the existing target-freshness checks stay green even if sanoid stops snapshotting entirely. The watchdog now also verifies `tank` and `ssd` have an `autosnap_` snapshot newer than 2h (sanoid runs every 10 min), and `sanoid.service` gets `OnFailure = nas-health-alert@`.

### 3. Prune-only sanoid policy on `tank/backups` (`storage.nix`)
Previously `autosnap = false; autoprune = false` — correct for not creating snapshots, but replicated `autosnap_` snapshots accumulated on the mirrors forever (source prunes per retention; targets kept everything). New `nas-backup-prune` template prunes with a retention superset of all source policies (`nas-default` and the shared `zfs-default`), so targets always keep ≥ source history. Sanoid only prunes snapshots matching its own naming: syncoid sync snaps and TrueNAS-era `auto-*` snapshots are untouched (the latter remains a manual decision, tracked in PLANNING.md).

### 4. Dead-man's switch (`health.nix`)
Everything so far alerts on *failure*; nothing alerts on *absence*. If the whole NAS hangs (the original TrueNAS failure mode), no `OnFailure` fires — and Grafana runs in an Incus container on this very host, while ntfy relays via the NUC. A new `nas-heartbeat` timer pings an external healthchecks-style URL every 5 minutes; the external service alerts when pings stop. Deliberately no `OnFailure` on the ping itself.

## Manual step after merge (not in this repo, like the replication keys)

Create a check on healthchecks.io (or similar; expected period 5 min, grace ~10–15 min), then on the NAS:

```bash
echo 'https://hc-ping.com/<uuid>' | sudo install -m 0600 /dev/stdin /etc/nas-heartbeat-url
```

Until then `nas-heartbeat` skips via `ConditionPathExists`.

## Validation

- `nix eval .#nixosConfigurations.nas.config.system.build.toplevel.drvPath` evaluates cleanly.
- Files formatted with nixfmt.
- Note: merging deploys via comin.

PLANNING.md updated to reflect all of the above, plus a new open item: verify every irreplaceable `tank` dataset (photos, photos-export, syncthing) has an off-machine backup path — the declared jobs only replicate `ssd` off-box.

### 5. Freshness check for the pc restic repo (`replication.nix`, second commit)

A 2026-07-09 review found pc's hourly restic backups had been failing **silently since 2026-03-22** on a stale repo lock (interrupted prune; the unit's own `unlock` step runs only after a successful backup, so it never fired). Nothing on the NAS watched `tank/backups/pc` — exactly the class of gap this PR is about. The watchdog now checks the mtime of the newest file in the repo's `snapshots/` directory (one file per completed restic snapshot; 26h limit for the hourly job).

Manual step on **pc** (not this repo): `sudo restic-truenas unlock`, then `sudo restic-truenas check`, then confirm the hourly timer resumes.

Re: the Greptile P1 on `check_autosnap` — false positive: with `-t snapshot`, `-d 1` lists only the dataset's own snapshots (child datasets are depth 1, their snapshots depth 2), verified live on the nas. Documented in a comment in the script.
