### PR TITLE
hetzner-matrix: MatrixRTC backend (LiveKit + lk-jwt-service) for Element Call

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/caddy.nix
+++ b/configs/nixos/hosts/hetzner-matrix/caddy.nix
@@ -2,7 +2,7 @@
 
 let
   constants = import ./constants.nix;
-  inherit (constants) siteDomain appDomain cinnyDomain pushDomain demoDomain demoTuwunelPort cinnyCurrentPath;
+  inherit (constants) siteDomain appDomain cinnyDomain pushDomain demoDomain demoTuwunelPort cinnyCurrentPath rtcJwtPort;
 in
 {
   systemd.tmpfiles.rules = [
@@ -31,9 +31,17 @@ in
           header Content-Type application/json
           header Access-Control-Allow-Origin "*"
           respond 200 {
-            body "{\"m.homeserver\":{\"base_url\":\"https://${siteDomain}\"}}"
+            body "{\"m.homeserver\":{\"base_url\":\"https://${siteDomain}\"},\"org.matrix.msc4143.rtc_foci\":[{\"type\":\"livekit\",\"livekit_service_url\":\"https://${siteDomain}/livekit/jwt\"}]}"
             close
           }
+        }
+
+        # MatrixRTC (Element Call) backend, path-routed to avoid extra DNS records.
+        handle_path /livekit/jwt/* {
+          reverse_proxy localhost:${toString rtcJwtPort}
+        }
+        handle_path /livekit/sfu/* {
+          reverse_proxy localhost:7880
         }
 
         handle / {

--- a/configs/nixos/hosts/hetzner-matrix/constants.nix
+++ b/configs/nixos/hosts/hetzner-matrix/constants.nix
@@ -6,6 +6,7 @@
   iosPushAppId = "chat.mindroom.app";
   demoDomain = "demo.mindroom.chat";
   demoTuwunelPort = 8018;
+  rtcJwtPort = 8090;
   cinnyCheckoutPath = "/var/www/cinny";
   cinnyPublishedPath = "/var/www/cinny-published";
   cinnyCurrentPath = "/var/www/cinny-published/current";

--- a/configs/nixos/hosts/hetzner-matrix/default.nix
+++ b/configs/nixos/hosts/hetzner-matrix/default.nix
@@ -16,6 +16,7 @@
     ./tuwunel.nix
     ./tuwunel-demo.nix
     ./caddy.nix
+    ./matrix-rtc.nix
     ./cinny.nix
     ./provisioning.nix
     ./sygnal.nix

--- a/configs/nixos/hosts/hetzner-matrix/matrix-rtc.nix
+++ b/configs/nixos/hosts/hetzner-matrix/matrix-rtc.nix
@@ -1,0 +1,46 @@
+# MatrixRTC backend for Element Call voice/video calls on mindroom.chat.
+#
+# LiveKit SFU carries the call media; lk-jwt-service (the MatrixRTC
+# authorization service) exchanges Matrix OpenID tokens for LiveKit JWTs.
+# Both are reverse-proxied under https://<siteDomain>/livekit/* by Caddy
+# (see caddy.nix), so no extra DNS records are needed. The client discovers
+# the service via org.matrix.msc4143.rtc_foci in /.well-known/matrix/client.
+{ config, ... }:
+
+let
+  constants = import ./constants.nix;
+  inherit (constants) siteDomain rtcJwtPort;
+in
+{
+  services.livekit = {
+    enable = true;
+    keyFile = config.age.secrets.livekit-keys.path;
+    settings = {
+      port = 7880;
+      rtc = {
+        use_external_ip = true;
+        tcp_port = 7881;
+        port_range_start = 50100;
+        port_range_end = 50200;
+      };
+    };
+  };
+
+  services.lk-jwt-service = {
+    enable = true;
+    livekitUrl = "wss://${siteDomain}/livekit/sfu";
+    keyFile = config.age.secrets.livekit-keys.path;
+    port = rtcJwtPort;
+  };
+
+  # WebRTC media goes directly to the SFU, not through Caddy.
+  networking.firewall = {
+    allowedTCPPorts = [ 7881 ];
+    allowedUDPPortRanges = [
+      {
+        from = 50100;
+        to = 50200;
+      }
+    ];
+  };
+}

--- a/configs/nixos/hosts/hetzner-matrix/secrets-config.nix
+++ b/configs/nixos/hosts/hetzner-matrix/secrets-config.nix
@@ -9,6 +9,10 @@
       group = "tuwunel";
       mode = "0400";
     };
+    livekit-keys = {
+      file = ./secrets/livekit-keys.age;
+      mode = "0400";
+    };
     registration-token-provisioning = {
       file = ./secrets/registration-token.age;
       owner = "mindroom-local-provisioning";

--- a/configs/nixos/hosts/hetzner-matrix/secrets/livekit-keys.age
+++ b/configs/nixos/hosts/hetzner-matrix/secrets/livekit-keys.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 S/2OdA MDkzRNaqbUovUo6gFuFoz0m1vM914lqT4oSbuqRRKT8
+6HQfrP60fFN2auTUPxy2ZrLyj3f9li/YZ8p9jqiWRuc
+-> ssh-ed25519 ahxGOQ zA/1eSwa+XPZ5NDs5eOkUd0oCpd41xagxE5cru1zPmQ
+mD8LgQ1IFok8WWScw4e5yH6L/rTXKyw+VrrTq/+yxDM
+--- sa6vxppPQ16ltLdfIPBENK/cHNcm9EryZZCPsFKe9Y8
+…ëöPIÌXx´ÔÏ–ìüV'Vý:nÛÒ¼%¾Ï²ÿ>ã„/S•5·HQ)Ýáõ«ëŽÀC–Xß’[5”x²Ý†Ä†¬â…ÿ›±Ô÷ý t8”Ú>½

--- a/configs/nixos/hosts/hetzner-matrix/secrets/secrets.nix
+++ b/configs/nixos/hosts/hetzner-matrix/secrets/secrets.nix
@@ -5,6 +5,7 @@ let
 in
 {
   "registration-token.age".publicKeys = recipients;
+  "livekit-keys.age".publicKeys = recipients;
   "sso-google-secret.age".publicKeys = recipients;
   "sso-github-secret.age".publicKeys = recipients;
   "sso-apple-secret.age".publicKeys = recipients;

--- a/configs/nixos/optional/mindroom-runtime-services.nix
+++ b/configs/nixos/optional/mindroom-runtime-services.nix
@@ -28,6 +28,7 @@ let
       export UV_PROJECT_ENVIRONMENT="${dir}/.venv-python314"
       exec uv run --python ${mindroomPython}/bin/python3 \
         --project "/srv/mindroom" \
+        --extra matrix_calls \
         --directory "${dir}" \
         mindroom ${args}
     '';


### PR DESCRIPTION
Adds the Element Call backend to the production Matrix host so MindRoom agents (mindroom-ai/mindroom#1452) and Cinny/Element clients can hold voice calls on mindroom.chat.

- `services.livekit`: SFU on localhost:7880, ICE/TCP 7881, UDP media 50100-50200, `use_external_ip` via STUN.
- `services.lk-jwt-service`: MatrixRTC authorization service on localhost:8090, exchanging Matrix OpenID tokens for LiveKit JWTs.
- Caddy: path-routed `https://mindroom.chat/livekit/jwt/*` and `wss://mindroom.chat/livekit/sfu/*` — avoids new DNS records (the `*.mindroom.chat` wildcard currently points at a stale IP, so a new subdomain would have needed a DNS change).
- `/.well-known/matrix/client` now advertises `org.matrix.msc4143.rtc_foci`, which is also what makes Cinny show call UI.
- New agenix secret `livekit-keys.age` (LiveKit API key/secret) consumed via systemd LoadCredential by both services.

Config evaluates cleanly (`nix eval ...#nixosConfigurations.hetzner-matrix...toplevel.drvPath`). Deployed to the host from this branch's flake ref.