### PR TITLE
Deploy from the MindRoom Chat repository

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/README.md
+++ b/configs/nixos/hosts/hetzner-matrix/README.md
@@ -1,6 +1,6 @@
 # hetzner-matrix
 
-Public Matrix homeserver ([Tuwunel](https://github.com/mindroom-ai/mindroom-tuwunel), MindRoom fork) on Hetzner Cloud ARM VPS with [Cinny](https://github.com/mindroom-ai/mindroom-cinny) web client.
+Public Matrix homeserver ([Tuwunel](https://github.com/mindroom-ai/mindroom-tuwunel), MindRoom fork) on Hetzner Cloud ARM VPS with the [MindRoom Chat](https://github.com/mindroom-ai/mindroom-chat) web client.
 
 Users run [MindRoom](https://github.com/mindroom-ai/mindroom) locally and connect to this server.
 
@@ -22,7 +22,7 @@ Nix-managed:
 
 Manual/runtime-managed:
 
-- Cinny build/deploy from `/var/www/cinny` into the published root at `/var/www/cinny-published/current`.
+- MindRoom Chat build/deploy from `/var/www/cinny` into the published root at `/var/www/cinny-published/current`.
 - Website files in `/var/www/mindroom`.
 - DNS records at your DNS provider.
 
@@ -53,7 +53,7 @@ If a previous failed server already exists, recreate it:
 
 Create A records pointing to the server IP:
 - `mindroom.chat` - website + Matrix `.well-known` delegation
-- `chat.mindroom.chat` - Cinny web client
+- `chat.mindroom.chat` - MindRoom Chat web client
 
 ### Tuwunel config (Nix-managed)
 
@@ -143,9 +143,9 @@ Onboarding flow:
 - DM `WhatsApp Bridge Bot` and send `login`, then scan QR in WhatsApp.
 - For Telegram, first set `MAUTRIX_TELEGRAM_TELEGRAM_API_ID` and `MAUTRIX_TELEGRAM_TELEGRAM_API_HASH` in `telegram-appservice-env.age`, then DM `Telegram Bridge Bot` and send `login`.
 
-### Cinny web client
+### MindRoom Chat web client
 
-Cinny build artifacts are not pinned in Nix.
+MindRoom Chat build artifacts are not pinned in Nix.
 The checkout at `/var/www/cinny` is ensured by the `git-checkout-cinny` systemd service.
 Caddy serves the published symlink at `/var/www/cinny-published/current`, so failed builds do not blank the live site.
 
@@ -157,7 +157,7 @@ sudo systemctl start git-checkout-cinny
 mindroom-publish-cinny v4.10.5-mindroom.X
 ```
 
-No `nixos-rebuild` is needed for Cinny-only updates.
+No `nixos-rebuild` is needed for MindRoom Chat-only updates.
 The publish command also sets a larger Node heap limit for the build and validates
 that `index.html`, `runtime-config.js`, and `assets/` exist before it updates the
 live symlink.

--- a/configs/nixos/hosts/hetzner-matrix/cinny.nix
+++ b/configs/nixos/hosts/hetzner-matrix/cinny.nix
@@ -72,20 +72,20 @@ EOF
       ln -s "$release_dir" "$next_link"
       mv -Tf "$next_link" "$current_link"
 
-      echo "Published Cinny ref $ref ($short_sha) to $release_dir"
+      echo "Published MindRoom Chat ref $ref ($short_sha) to $release_dir"
       echo "Live root now points at $current_link"
     '';
   };
 in
 {
-  # MindRoom Cinny fork checkout is Nix-managed. Published static assets live
+  # MindRoom Chat checkout is Nix-managed. Published static assets live
   # outside the checkout so a failed build cannot blank the live site.
   # Build/update remains operator-triggered via `mindroom-publish-cinny`.
   services.git-repo-checkouts = {
     enable = true;
     repositories.cinny = {
       path = cinnyCheckoutPath;
-      url = "https://github.com/mindroom-ai/mindroom-cinny.git";
+      url = "https://github.com/mindroom-ai/mindroom-chat.git";
       branch = "dev";
       user = "basnijholt";
       group = "users";

--- a/configs/nixos/hosts/mindroom/cinny.nix
+++ b/configs/nixos/hosts/mindroom/cinny.nix
@@ -4,7 +4,7 @@
     enable = true;
     repositories.cinny = {
       path = "/var/www/cinny";
-      url = "https://github.com/mindroom-ai/mindroom-cinny.git";
+      url = "https://github.com/mindroom-ai/mindroom-chat.git";
       branch = "dev";
       user = "basnijholt";
       group = "users";

--- a/configs/nixos/optional/mindroom-runtime-services.nix
+++ b/configs/nixos/optional/mindroom-runtime-services.nix
@@ -136,7 +136,7 @@ in
     };
 
     mindroom-cinny = {
-      description = "MindRoom Web UI (Cinny fork)";
+      description = "MindRoom Chat web UI";
       after = [ "network-online.target" "git-checkout-cinny.service" ];
       wants = [ "network-online.target" "git-checkout-cinny.service" ];
       wantedBy = [ "multi-user.target" ];

--- a/configs/nixos/optional/mindroom-runtime-services.nix
+++ b/configs/nixos/optional/mindroom-runtime-services.nix
@@ -147,7 +147,6 @@ in
       ];
       serviceConfig = {
         Type = "oneshot";
-        RemainAfterExit = true;
         User = "basnijholt";
         Group = "users";
         WorkingDirectory = "/var/www/cinny";

--- a/configs/nixos/optional/mindroom-runtime-services.nix
+++ b/configs/nixos/optional/mindroom-runtime-services.nix
@@ -135,10 +135,50 @@ in
       extraEnvironment = [ "BACKEND_PORT=8766" ];
     };
 
-    mindroom-cinny = {
-      description = "MindRoom Chat web UI";
+    mindroom-cinny-dependencies = {
+      description = "Install MindRoom Chat dependencies";
       after = [ "network-online.target" "git-checkout-cinny.service" ];
       wants = [ "network-online.target" "git-checkout-cinny.service" ];
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        bash
+        coreutils
+        nodejs_22
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "basnijholt";
+        Group = "users";
+        WorkingDirectory = "/var/www/cinny";
+      };
+      script = ''
+        set -euo pipefail
+
+        lock_hash="$(sha256sum package-lock.json | cut -d ' ' -f 1)"
+        marker=".git/mindroom-node-modules-lock-hash"
+        if [ -d node_modules ] && [ -f "$marker" ] && [ "$(cat "$marker")" = "$lock_hash" ]; then
+          exit 0
+        fi
+
+        npm ci
+        printf '%s\n' "$lock_hash" > "$marker"
+      '';
+    };
+
+    mindroom-cinny = {
+      description = "MindRoom Chat web UI";
+      after = [
+        "network-online.target"
+        "git-checkout-cinny.service"
+        "mindroom-cinny-dependencies.service"
+      ];
+      wants = [
+        "network-online.target"
+        "git-checkout-cinny.service"
+        "mindroom-cinny-dependencies.service"
+      ];
+      requires = [ "mindroom-cinny-dependencies.service" ];
       wantedBy = [ "multi-user.target" ];
       path = with pkgs; [ bash nodejs_22 ];
       serviceConfig = {


### PR DESCRIPTION
## Summary

- source both MindRoom Chat checkouts from `mindroom-ai/mindroom-chat`
- update production deployment documentation and operator output
- describe the existing `mindroom-cinny` unit as the MindRoom Chat web UI

## Compatibility

Existing checkout paths, systemd unit names, repository keys, and the `mindroom-publish-cinny` command remain unchanged.

## Validation

- `nix flake check ./configs/nixos`
- `git diff --check`
