### PR TITLE
Update Tuwunel to v1.8.1-mindroom.3

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/constants.nix
+++ b/configs/nixos/hosts/hetzner-matrix/constants.nix
@@ -10,6 +10,6 @@
   cinnyCheckoutPath = "/var/www/cinny";
   cinnyPublishedPath = "/var/www/cinny-published";
   cinnyCurrentPath = "/var/www/cinny-published/current";
-  tuwunelVersion = "v1.8.1-mindroom.1";
-  tuwunelArchiveHash = "sha256-IqCgYjNai29GViHvAF0dnnaKMA/YAJbU9L4xaRPKe1c=";
+  tuwunelVersion = "v1.8.1-mindroom.3";
+  tuwunelArchiveHash = "sha256-pS5u+PYb9cw7K0FNesjYayKmjwxkOie4GgJ0uoak7oY=";
 }

--- a/configs/nixos/hosts/mindroom/constants.nix
+++ b/configs/nixos/hosts/mindroom/constants.nix
@@ -9,6 +9,6 @@ in
   publicSiteDomain = siteDomain;
   publicCinnyDomain = "chat.lab.mindroom.chat";
   publicElementDomain = "element.lab.mindroom.chat";
-  tuwunelVersion = "v1.8.1-mindroom.1";
-  tuwunelArchiveHash = "sha256-chAjqW1ti3rJa3VuOwqqc7i5Ez4ditAjJX/YaQoChyA=";
+  tuwunelVersion = "v1.8.1-mindroom.3";
+  tuwunelArchiveHash = "sha256-6AM159GjV2T3qzBz1woEYOgXQx5EKq8GcbU1+ENFcKM=";
 }


### PR DESCRIPTION
Updates both Matrix hosts to the released Tuwunel build containing terminal-only MindRoom streaming push notifications.

Verified both release archives with Nix prefetch and evaluated the hetzner-matrix and mindroom NixOS configurations locally.