### PR TITLE
Pin pull-source host keys (first pulls fail host key verification)

### DIFF
--- a/configs/nixos/common/services.nix
+++ b/configs/nixos/common/services.nix
@@ -46,5 +46,27 @@
       ];
       publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBVVgr3VXPWMUMtvTatRBBmnvfMfAhBH9qvNjv0Kl7sD";
     };
+    # Sources of the NAS pull replication (PR #75): root@nas connects with
+    # BatchMode=yes, which hard-fails on unknown host keys — the first pull
+    # to each host died exactly that way. Keys read from each host's
+    # /etc/ssh/ssh_host_ed25519_key.pub over authenticated SSH, 2026-07-24.
+    # pc's survives reinstalls by design (host keys ride in the recovery
+    # kit); a reinstalled hp/pi4/nuc must update its entry here.
+    "pc" = {
+      hostNames = [ "pc" "192.168.1.5" ];
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMjiKKO6ajlHe5oZa9fGI1v9yLvjvuBH3ZZlYlCIlREt";
+    };
+    "nuc" = {
+      hostNames = [ "nuc" "192.168.1.2" ];
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPRL54JIesy0f1FtG81ABXq/xbNNyUFXTA5qZWNoW097";
+    };
+    "hp" = {
+      hostNames = [ "hp" "192.168.1.3" ];
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM5ZinYz3ul3fbg/+eA95t0dq0yBQw4UxBMyFKUihSTQ";
+    };
+    "pi4" = {
+      hostNames = [ "pi4" "192.168.1.7" ];
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGJO+VhVe+mC9mQa0dyOT6fPmIxkTHeM5X0IdcpF4mGY";
+    };
   };
 }

--- a/configs/nixos/common/services.nix
+++ b/configs/nixos/common/services.nix
@@ -48,8 +48,7 @@
     };
     # Pull replication connects as root@nas with BatchMode=yes, which
     # hard-fails on unknown host keys, so every source must be pinned here.
-    # pc's key survives reinstalls (it rides in the recovery kit); a
-    # reinstalled nuc/hp/pi4 must update its entry.
+    # Reinstalled host gets new keys — update its entry here.
     "pc" = {
       hostNames = [ "pc" "192.168.1.5" ];
       publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMjiKKO6ajlHe5oZa9fGI1v9yLvjvuBH3ZZlYlCIlREt";

--- a/configs/nixos/common/services.nix
+++ b/configs/nixos/common/services.nix
@@ -46,12 +46,10 @@
       ];
       publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBVVgr3VXPWMUMtvTatRBBmnvfMfAhBH9qvNjv0Kl7sD";
     };
-    # Sources of the NAS pull replication (PR #75): root@nas connects with
-    # BatchMode=yes, which hard-fails on unknown host keys — the first pull
-    # to each host died exactly that way. Keys read from each host's
-    # /etc/ssh/ssh_host_ed25519_key.pub over authenticated SSH, 2026-07-24.
-    # pc's survives reinstalls by design (host keys ride in the recovery
-    # kit); a reinstalled hp/pi4/nuc must update its entry here.
+    # Pull replication connects as root@nas with BatchMode=yes, which
+    # hard-fails on unknown host keys, so every source must be pinned here.
+    # pc's key survives reinstalls (it rides in the recovery kit); a
+    # reinstalled nuc/hp/pi4 must update its entry.
     "pc" = {
       hostNames = [ "pc" "192.168.1.5" ];
       publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMjiKKO6ajlHe5oZa9fGI1v9yLvjvuBH3ZZlYlCIlREt";


### PR DESCRIPTION
Follow-up to #75: root@nas has no known_hosts entries for pc/hp/pi4, and syncoid uses BatchMode=yes → "Host key verification failed" on the first pull (observed on nas-replicate-pc). Pins all four source ed25519 keys in programs.ssh.knownHosts, read from each host's /etc/ssh over authenticated SSH. Merge with scripts/merge-pr.sh. Note: pc's pull was already unblocked imperatively on the NAS (root known_hosts append); hp/pi4 need this merged+deployed before their 01:44/01:51 timers.