### PR TITLE
feat(pc): keep sanoid off the incus datasets (zroot/incus)

### DIFF
--- a/configs/nixos/hosts/hp/default.nix
+++ b/configs/nixos/hosts/hp/default.nix
@@ -25,13 +25,6 @@
 
   local.zfsReplicationSource.nasPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINLaIVBmPIbB7Ot1V2bYKMnoLKj9Ga5LeMBafLzPfg7L nas-replication-hp";
 
-  # Incus manages its own snapshots; keep sanoid away from its datasets.
-  services.sanoid.datasets."zroot/incus" = {
-    autosnap = false;
-    autoprune = false;
-    recursive = true;
-  };
-
   # Small pool: long-lived snapshots pin churn the disk can't afford. Keep
   # short-term rollback, cut the long tail; the NAS mirror holds deep history.
   # Dataset-level values override the zfs-default template.

--- a/configs/nixos/hosts/pc/default.nix
+++ b/configs/nixos/hosts/pc/default.nix
@@ -36,6 +36,13 @@
   local.wakeOnLan.interface = "enp5s0";
   local.zfsReplicationSource.nasPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFf8RpaZe1lGYuLI9ASLGLd6zNlkhIlRXK8hpuXiq+Os nas-replication-pc";
 
+  # Incus manages its own snapshots; keep sanoid away from its datasets.
+  services.sanoid.datasets."zroot/incus" = {
+    autosnap = false;
+    autoprune = false;
+    recursive = true;
+  };
+
   # Required for DDC/CI tools such as ddcutil to read monitor state (e.g. the
   # active input source) for manual diagnostics. Display automation no longer
   # depends on it; Sunshine drives dummy-output switching via sunshine-mode.sh.

--- a/configs/nixos/hosts/pc/default.nix
+++ b/configs/nixos/hosts/pc/default.nix
@@ -36,13 +36,6 @@
   local.wakeOnLan.interface = "enp5s0";
   local.zfsReplicationSource.nasPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFf8RpaZe1lGYuLI9ASLGLd6zNlkhIlRXK8hpuXiq+Os nas-replication-pc";
 
-  # Incus manages its own snapshots; keep sanoid away from its datasets.
-  services.sanoid.datasets."zroot/incus" = {
-    autosnap = false;
-    autoprune = false;
-    recursive = true;
-  };
-
   # Required for DDC/CI tools such as ddcutil to read monitor state (e.g. the
   # active input source) for manual diagnostics. Display automation no longer
   # depends on it; Sunshine drives dummy-output switching via sunshine-mode.sh.

--- a/configs/nixos/optional/virtualization.nix
+++ b/configs/nixos/optional/virtualization.nix
@@ -7,4 +7,14 @@
   virtualisation.libvirtd.enable = true;
   virtualisation.incus.enable = true;
   programs.virt-manager.enable = true;
+
+  # Incus manages its own snapshots; keep sanoid away from its datasets.
+  # Fleet convention: the incus storage pool lives on zroot/incus. Inert on
+  # hosts without sanoid; on hosts where the dataset does not exist (yet),
+  # sanoid logs one harmless zfs-list complaint per run and carries on.
+  services.sanoid.datasets."zroot/incus" = {
+    autosnap = false;
+    autoprune = false;
+    recursive = true;
+  };
 }


### PR DESCRIPTION
Post-migration aftercare: pc's incus still runs on the dir pool inside /var, so container churn lands in every zroot/var autosnap. This adds the hp-style sanoid exclusion for zroot/incus; the pool move itself is a one-time imperative step (below), same as it was on hp.

Once zroot/incus exists, the NAS nightly pull adopts it automatically (replication.nix probes `zfs list zroot/incus` on each source) — mindroom then gets mirrored to tank/backups/pc/incus instead of riding inside var.

## One-time move (run with both containers stopped, ~20-30 min)

End state identical to hp (pool `default`, driver zfs). Pools can't be renamed, and the dir pool holds the name, so it takes two hops via a staging pool:

```bash
incus stop mindroom dev-lxc
sudo zfs create -o mountpoint=none zroot/incus-migrate
incus storage create staging zfs source=zroot/incus-migrate
incus move mindroom --storage staging
incus move dev-lxc --storage staging
incus profile device set default root pool=staging
incus image list   # then: incus image delete <fingerprint...>  (re-downloadable)
incus storage delete default
sudo zfs create -o mountpoint=none zroot/incus
incus storage create default zfs source=zroot/incus
incus move mindroom --storage default
incus move dev-lxc --storage default
incus profile device set default root pool=default
incus storage delete staging
sudo zfs destroy -r zroot/incus-migrate
incus start mindroom dev-lxc
```

If `incus move <name> --storage <pool>` refuses the in-place pool move, the fallback is a rename round-trip: `incus move X X-tmp --storage <pool> && incus move X-tmp X`.

Validation: `nix eval .#nixosConfigurations.pc.config.system.build.toplevel.drvPath` evaluates cleanly. Merge via scripts/merge-pr.sh (comin needs the signed merge).