### PR TITLE
chore(hetzner): bump tuwunel to v1.8.2-mindroom.3

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/constants.nix
+++ b/configs/nixos/hosts/hetzner-matrix/constants.nix
@@ -10,6 +10,6 @@
   cinnyCheckoutPath = "/var/www/cinny";
   cinnyPublishedPath = "/var/www/cinny-published";
   cinnyCurrentPath = "/var/www/cinny-published/current";
-  tuwunelVersion = "v1.8.1-mindroom.6";
-  tuwunelArchiveHash = "sha256-kLcbuEVvtUjiFG+AAAtQSVYS5RaQIxe/HG5/TpLQl+w=";
+  tuwunelVersion = "v1.8.2-mindroom.3";
+  tuwunelArchiveHash = "sha256-yofU3/HteETU6WAgwVbxVs0JTW8U15EUCXZttALaNWg=";
 }


### PR DESCRIPTION
Bumps the production Hetzner Matrix host from `v1.8.1-mindroom.6` to `v1.8.2-mindroom.3`.

- Upstream Tuwunel 1.8.2
- fix(api): clamp `/messages` pagination at the `to` position (mindroom-tuwunel#11)

Hash prefetched with `nix store prefetch-file` for the `linux-aarch64` tarball (the arch `tuwunel.nix` fetches on this host).

Applied and verified on `mindroom-hetzner` via `nixos-rebuild switch`.