### PR TITLE
feat(hetzner-matrix): tuwunel v1.8.2-mindroom.4

### DIFF
--- a/configs/nixos/hosts/hetzner-matrix/constants.nix
+++ b/configs/nixos/hosts/hetzner-matrix/constants.nix
@@ -10,6 +10,6 @@
   cinnyCheckoutPath = "/var/www/cinny";
   cinnyPublishedPath = "/var/www/cinny-published";
   cinnyCurrentPath = "/var/www/cinny-published/current";
-  tuwunelVersion = "v1.8.2-mindroom.3";
-  tuwunelArchiveHash = "sha256-yofU3/HteETU6WAgwVbxVs0JTW8U15EUCXZttALaNWg=";
+  tuwunelVersion = "v1.8.2-mindroom.4";
+  tuwunelArchiveHash = "sha256-dgC7MZhLgwuUsaM5obV/PJS7XfsEXJP5JGiqAoqXk+w=";
 }


### PR DESCRIPTION
Bump tuwunel v1.8.2-mindroom.3 → .4; archive hash prefetched from the release tarball.