### PR TITLE
Track autonomous Baspowers fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 [submodule "submodules/tmux"]
 	path = submodules/tmux
 	url = https://github.com/gpakosz/.tmux.git
+[submodule "submodules/baspowers"]
+	path = submodules/baspowers
+	url = git@github.com:basnijholt/baspowers.git
+	branch = bas/autonomous-workflow

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -71,7 +71,7 @@
   "enabledPlugins": {
     "claude-code-wakatime@wakatime": true,
     "agent-cli-dev@agent-cli": true,
-    "superpowers@claude-plugins-official": true
+    "baspowers@baspowers-dev": true
   },
   "outputStyle": "caveman",
   "effortLevel": "xhigh",

--- a/configs/codex/AGENTS.md
+++ b/configs/codex/AGENTS.md
@@ -1,10 +1,15 @@
-- Always use the `caveman` skill for every response in every project.
-- Default to `/caveman full` unless I explicitly say `/caveman lite`, `/caveman ultra`, `stop caveman`, or `normal mode`.
-- Begin with a concise checklist (3-7 bullets) of what you will do; keep items conceptual, not implementation-level.
-- Always run `git status` before using `git add -A` or `git add .` to verify which files will be staged. This prevents accidentally adding unwanted files to your commit.
-- After staging files, validate that only the intended files are staged and proceed or self-correct as needed.
-- Never amend a commit once it is made. Commit history should remain unchanged to maintain the integrity of the project history.
-- Do not run `python`, `python3`, `pip`, or `pip3` directly. Always use `uv run` or `uv sync --all-extras` to ensure the correct virtual environment and dependencies are used for the project.
-- Most projects utilize `pre-commit` hooks to automate code formatting and linting.
-- Only make the minimal necessary changes to complete your task.
-- Avoid making changes that are not directly related to the task at hand.
+- Invoke `baspowers:using-baspowers` before every response or action, then use every applicable skill.
+- Use the `caveman` skill for every response in every project. Default to `/caveman full` unless I explicitly choose another level or say `stop caveman` or `normal mode`.
+- Never create branch names beginning with `codex/`.
+- Begin with a concise conceptual checklist of 3-7 items.
+- Make routine, reversible, in-scope decisions autonomously. Ask only for missing intent, material scope expansion, or authority for destructive, irreversible, security-sensitive, or external actions.
+- For a hard technical decision that remains ambiguous after inspecting evidence, use `baspowers:consulting-cross-model`: Codex consults Claude; Claude consults Codex through `agent-cli dev`.
+- Never commit `docs/baspowers/*`.
+- Never add long absolute paths, `PATH`, or other non-portable environment variables to PR descriptions. Use repository-relative paths.
+- Never open draft PRs. Normal PRs trigger AI review; wait for it, validate its comments, and address valid findings.
+- Never place durable development worktrees, uncommitted implementation work, living handoffs, or campaign evidence under `/tmp`, `/private/tmp`, or another temporary directory. Use `~/.codex/worktrees/` or the repository's persistent worktree area.
+- Run `git status` before `git add -A` or `git add .`. After staging, verify only intended files are staged.
+- Never amend a commit.
+- Do not run `python`, `python3`, `pip`, or `pip3` directly. Use `uv run` or `uv sync --all-extras`.
+- Prefer repository `pre-commit` hooks when available.
+- Make only minimal changes directly related to the task.

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -20,6 +20,7 @@
     ~/.config/cmux/cmux.json: configs/cmux/cmux.json
     ~/.config/codex/AGENTS.md: configs/codex/AGENTS.md
     ~/.config/codex/config.toml: configs/codex/config.toml
+    ~/.codex/AGENTS.md: configs/codex/AGENTS.md
     ~/.codex/hooks: configs/codex/hooks
     ~/.codex/hooks.json: configs/codex/hooks.json
     ~/.config/dask/distributed.yaml: configs/dask/distributed.yaml
@@ -75,6 +76,7 @@
   - command: bash scripts/sync-secrets.sh
     stdout: true
   - git submodule update --init --recursive
+  - bash scripts/sync-baspowers.sh
 
 # -- Only on Linux --
 - defaults:

--- a/scripts/sync-baspowers.sh
+++ b/scripts/sync-baspowers.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+plugin_root="$repo_root/submodules/baspowers"
+codex_bin=${CODEX_BASPOWERS_CODEX_BIN:-codex}
+claude_bin=${CODEX_BASPOWERS_CLAUDE_BIN:-claude}
+legacy_name='super''powers'
+codex_local=baspowers@baspowers-dev
+codex_fallback="$legacy_name@openai-curated"
+claude_local=baspowers@baspowers-dev
+claude_fallback="$legacy_name@claude-plugins-official"
+legacy_local="$legacy_name@$legacy_name-dev"
+legacy_marketplace="$legacy_name-dev"
+
+if [[ ! -f "$plugin_root/.agents/plugins/marketplace.json" ]]; then
+  printf 'Baspowers submodule is missing. Run git submodule update --init submodules/baspowers.\n' >&2
+  exit 1
+fi
+
+plugins=$("$codex_bin" plugin list --json)
+compact_plugins=${plugins//[[:space:]]/}
+if { grep -Fq "\"pluginId\":\"$codex_local\"" <<<"$compact_plugins" ||
+  grep -Fq "\"pluginId\":\"$legacy_local\"" <<<"$compact_plugins"; } &&
+  ! grep -Fq "\"pluginId\":\"$codex_fallback\"" <<<"$compact_plugins"; then
+  # Keep a working fallback installed until the local replacement validates.
+  "$codex_bin" plugin add "$codex_fallback"
+fi
+
+if grep -Fq "\"pluginId\":\"$codex_local\"" <<<"$compact_plugins"; then
+  "$codex_bin" plugin remove "$codex_local"
+fi
+if grep -Fq "\"pluginId\":\"$legacy_local\"" <<<"$compact_plugins"; then
+  "$codex_bin" plugin remove "$legacy_local"
+fi
+
+marketplaces=$("$codex_bin" plugin marketplace list --json)
+compact_marketplaces=${marketplaces//[[:space:]]/}
+if grep -Fq '"name":"baspowers-dev"' <<<"$compact_marketplaces"; then
+  "$codex_bin" plugin marketplace remove baspowers-dev
+fi
+if grep -Fq "\"name\":\"$legacy_marketplace\"" <<<"$compact_marketplaces"; then
+  "$codex_bin" plugin marketplace remove "$legacy_marketplace"
+fi
+
+"$codex_bin" plugin marketplace add "$plugin_root"
+"$codex_bin" plugin add "$codex_local"
+
+plugins=$("$codex_bin" plugin list --json)
+if ! grep -Fq "\"pluginId\":\"$codex_local\"" <<<"${plugins//[[:space:]]/}"; then
+  printf 'Local Baspowers plugin did not install successfully.\n' >&2
+  exit 1
+fi
+
+if grep -Fq "\"pluginId\":\"$codex_fallback\"" <<<"${plugins//[[:space:]]/}"; then
+  "$codex_bin" plugin remove "$codex_fallback"
+fi
+
+printf 'Codex Baspowers plugin uses %s\n' "$plugin_root"
+
+plugins=$("$claude_bin" plugin list --json)
+compact_plugins=${plugins//[[:space:]]/}
+if { grep -Fq "\"id\":\"$claude_local\"" <<<"$compact_plugins" ||
+  grep -Fq "\"id\":\"$legacy_local\"" <<<"$compact_plugins"; } &&
+  ! grep -Fq "\"id\":\"$claude_fallback\"" <<<"$compact_plugins"; then
+  "$claude_bin" plugin install "$claude_fallback"
+fi
+
+if grep -Fq "\"id\":\"$claude_local\"" <<<"$compact_plugins"; then
+  "$claude_bin" plugin uninstall "$claude_local"
+fi
+if grep -Fq "\"id\":\"$legacy_local\"" <<<"$compact_plugins"; then
+  "$claude_bin" plugin uninstall "$legacy_local"
+fi
+
+marketplaces=$("$claude_bin" plugin marketplace list --json)
+compact_marketplaces=${marketplaces//[[:space:]]/}
+if grep -Fq '"name":"baspowers-dev"' <<<"$compact_marketplaces"; then
+  "$claude_bin" plugin marketplace remove baspowers-dev
+fi
+if grep -Fq "\"name\":\"$legacy_marketplace\"" <<<"$compact_marketplaces"; then
+  "$claude_bin" plugin marketplace remove "$legacy_marketplace"
+fi
+
+"$claude_bin" plugin marketplace add "$plugin_root"
+"$claude_bin" plugin install "$claude_local"
+
+plugins=$("$claude_bin" plugin list --json)
+if ! grep -Fq "\"id\":\"$claude_local\"" <<<"${plugins//[[:space:]]/}"; then
+  printf 'Local Baspowers plugin did not install successfully in Claude.\n' >&2
+  exit 1
+fi
+
+if grep -Fq "\"id\":\"$claude_fallback\"" <<<"${plugins//[[:space:]]/}"; then
+  "$claude_bin" plugin uninstall "$claude_fallback"
+fi
+
+printf 'Claude Baspowers plugin uses %s\n' "$plugin_root"

--- a/scripts/sync-baspowers.sh
+++ b/scripts/sync-baspowers.sh
@@ -3,96 +3,48 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 plugin_root="$repo_root/submodules/baspowers"
-codex_bin=${CODEX_BASPOWERS_CODEX_BIN:-codex}
-claude_bin=${CODEX_BASPOWERS_CLAUDE_BIN:-claude}
-legacy_name='super''powers'
-codex_local=baspowers@baspowers-dev
-codex_fallback="$legacy_name@openai-curated"
-claude_local=baspowers@baspowers-dev
-claude_fallback="$legacy_name@claude-plugins-official"
-legacy_local="$legacy_name@$legacy_name-dev"
-legacy_marketplace="$legacy_name-dev"
+codex_bin=${BASPOWERS_CODEX_BIN:-codex}
+claude_bin=${BASPOWERS_CLAUDE_BIN:-claude}
+local_plugin=baspowers@baspowers-dev
+legacy='super''powers'
 
 if [[ ! -f "$plugin_root/.agents/plugins/marketplace.json" ]]; then
   printf 'Baspowers submodule is missing. Run git submodule update --init submodules/baspowers.\n' >&2
   exit 1
 fi
 
-plugins=$("$codex_bin" plugin list --json)
-compact_plugins=${plugins//[[:space:]]/}
-if { grep -Fq "\"pluginId\":\"$codex_local\"" <<<"$compact_plugins" ||
-  grep -Fq "\"pluginId\":\"$legacy_local\"" <<<"$compact_plugins"; } &&
-  ! grep -Fq "\"pluginId\":\"$codex_fallback\"" <<<"$compact_plugins"; then
-  # Keep a working fallback installed until the local replacement validates.
-  "$codex_bin" plugin add "$codex_fallback"
-fi
+ignore_failure() {
+  "$@" >/dev/null 2>&1 || true
+}
 
-if grep -Fq "\"pluginId\":\"$codex_local\"" <<<"$compact_plugins"; then
-  "$codex_bin" plugin remove "$codex_local"
-fi
-if grep -Fq "\"pluginId\":\"$legacy_local\"" <<<"$compact_plugins"; then
-  "$codex_bin" plugin remove "$legacy_local"
-fi
-
-marketplaces=$("$codex_bin" plugin marketplace list --json)
-compact_marketplaces=${marketplaces//[[:space:]]/}
-if grep -Fq '"name":"baspowers-dev"' <<<"$compact_marketplaces"; then
-  "$codex_bin" plugin marketplace remove baspowers-dev
-fi
-if grep -Fq "\"name\":\"$legacy_marketplace\"" <<<"$compact_marketplaces"; then
-  "$codex_bin" plugin marketplace remove "$legacy_marketplace"
-fi
-
+ignore_failure "$codex_bin" plugin remove "$local_plugin"
+ignore_failure "$codex_bin" plugin marketplace remove baspowers-dev
 "$codex_bin" plugin marketplace add "$plugin_root"
-"$codex_bin" plugin add "$codex_local"
+"$codex_bin" plugin add "$local_plugin"
 
 plugins=$("$codex_bin" plugin list --json)
-if ! grep -Fq "\"pluginId\":\"$codex_local\"" <<<"${plugins//[[:space:]]/}"; then
-  printf 'Local Baspowers plugin did not install successfully.\n' >&2
+if ! grep -Fq '"pluginId":"baspowers@baspowers-dev"' <<<"${plugins//[[:space:]]/}"; then
+  printf 'Codex did not install the local Baspowers plugin.\n' >&2
   exit 1
 fi
 
-if grep -Fq "\"pluginId\":\"$codex_fallback\"" <<<"${plugins//[[:space:]]/}"; then
-  "$codex_bin" plugin remove "$codex_fallback"
-fi
-
+ignore_failure "$codex_bin" plugin remove "$legacy@$legacy-dev"
+ignore_failure "$codex_bin" plugin marketplace remove "$legacy-dev"
+ignore_failure "$codex_bin" plugin remove "$legacy@openai-curated"
 printf 'Codex Baspowers plugin uses %s\n' "$plugin_root"
 
-plugins=$("$claude_bin" plugin list --json)
-compact_plugins=${plugins//[[:space:]]/}
-if { grep -Fq "\"id\":\"$claude_local\"" <<<"$compact_plugins" ||
-  grep -Fq "\"id\":\"$legacy_local\"" <<<"$compact_plugins"; } &&
-  ! grep -Fq "\"id\":\"$claude_fallback\"" <<<"$compact_plugins"; then
-  "$claude_bin" plugin install "$claude_fallback"
-fi
-
-if grep -Fq "\"id\":\"$claude_local\"" <<<"$compact_plugins"; then
-  "$claude_bin" plugin uninstall "$claude_local"
-fi
-if grep -Fq "\"id\":\"$legacy_local\"" <<<"$compact_plugins"; then
-  "$claude_bin" plugin uninstall "$legacy_local"
-fi
-
-marketplaces=$("$claude_bin" plugin marketplace list --json)
-compact_marketplaces=${marketplaces//[[:space:]]/}
-if grep -Fq '"name":"baspowers-dev"' <<<"$compact_marketplaces"; then
-  "$claude_bin" plugin marketplace remove baspowers-dev
-fi
-if grep -Fq "\"name\":\"$legacy_marketplace\"" <<<"$compact_marketplaces"; then
-  "$claude_bin" plugin marketplace remove "$legacy_marketplace"
-fi
-
+ignore_failure "$claude_bin" plugin uninstall "$local_plugin"
+ignore_failure "$claude_bin" plugin marketplace remove baspowers-dev
 "$claude_bin" plugin marketplace add "$plugin_root"
-"$claude_bin" plugin install "$claude_local"
+"$claude_bin" plugin install "$local_plugin"
 
 plugins=$("$claude_bin" plugin list --json)
-if ! grep -Fq "\"id\":\"$claude_local\"" <<<"${plugins//[[:space:]]/}"; then
-  printf 'Local Baspowers plugin did not install successfully in Claude.\n' >&2
+if ! grep -Fq '"id":"baspowers@baspowers-dev"' <<<"${plugins//[[:space:]]/}"; then
+  printf 'Claude did not install the local Baspowers plugin.\n' >&2
   exit 1
 fi
 
-if grep -Fq "\"id\":\"$claude_fallback\"" <<<"${plugins//[[:space:]]/}"; then
-  "$claude_bin" plugin uninstall "$claude_fallback"
-fi
-
+ignore_failure "$claude_bin" plugin uninstall "$legacy@$legacy-dev"
+ignore_failure "$claude_bin" plugin marketplace remove "$legacy-dev"
+ignore_failure "$claude_bin" plugin uninstall "$legacy@claude-plugins-official"
 printf 'Claude Baspowers plugin uses %s\n' "$plugin_root"

--- a/tests/test-sync-baspowers.sh
+++ b/tests/test-sync-baspowers.sh
@@ -6,198 +6,63 @@ script="$repo_root/scripts/sync-baspowers.sh"
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 
-stub="$test_root/codex"
-state="$test_root/state"
-log="$test_root/mutations.log"
-claude_stub="$test_root/claude"
-claude_state="$test_root/claude-state"
-claude_log="$test_root/claude-mutations.log"
-mkdir -p "$state" "$claude_state"
+log="$test_root/commands.log"
+stub="$test_root/plugin-cli"
 legacy='super''powers'
 
 cat >"$stub" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 
-state=${CODEX_BASPOWERS_TEST_STATE:?}
-log=${CODEX_BASPOWERS_TEST_LOG:?}
-legacy='super''powers'
+printf '%s %s\n' "$(basename "$0")" "$*" >>"${BASPOWERS_TEST_LOG:?}"
 
-case "$*" in
-  "plugin marketplace list --json")
-    if [[ -e "$state/marketplace" ]]; then
-      printf '{"marketplaces":[{"name":"baspowers-dev"}]}\n'
-    else
-      printf '{"marketplaces":[]}\n'
-    fi
-    ;;
-  "plugin marketplace add "*)
-    printf '%s\n' "$*" >>"$log"
-    touch "$state/marketplace"
-    ;;
-  "plugin marketplace remove baspowers-dev")
-    printf '%s\n' "$*" >>"$log"
-    rm -f "$state/marketplace"
-    ;;
-  "plugin list --json")
-    printf '{"installed":['
-    sep=
-    if [[ ! -e "$state/official_removed" ]]; then
-      printf '{"pluginId":"%s@openai-curated"}' "$legacy"
-      sep=,
-    fi
-    if [[ -e "$state/local" ]]; then
-      printf '%s{"pluginId":"baspowers@baspowers-dev"}' "$sep"
-    fi
-    printf ']}\n'
-    ;;
-  "plugin add baspowers@baspowers-dev")
-    printf '%s\n' "$*" >>"$log"
-    if [[ -e "$state/fail_local_add" ]]; then
-      exit 1
-    fi
-    touch "$state/local"
-    ;;
-  "plugin add ${legacy}@openai-curated")
-    printf '%s\n' "$*" >>"$log"
-    rm -f "$state/official_removed"
-    ;;
-  "plugin remove ${legacy}@openai-curated")
-    printf '%s\n' "$*" >>"$log"
-    touch "$state/official_removed"
-    ;;
-  "plugin remove baspowers@baspowers-dev")
-    printf '%s\n' "$*" >>"$log"
-    rm -f "$state/local"
-    ;;
-  *)
-    printf 'unexpected codex invocation: %s\n' "$*" >&2
-    exit 2
-    ;;
-esac
+if [[ "$*" == "plugin list --json" ]]; then
+  if [[ -e "${BASPOWERS_TEST_MISSING:-}" ]]; then
+    printf '[]\n'
+  elif [[ $(basename "$0") == codex ]]; then
+    printf '{"installed":[{"pluginId":"baspowers@baspowers-dev"}]}\n'
+  else
+    printf '[{"id":"baspowers@baspowers-dev"}]\n'
+  fi
+fi
 STUB
 chmod +x "$stub"
+ln -s "$stub" "$test_root/codex"
+ln -s "$stub" "$test_root/claude"
 
-cat >"$claude_stub" <<'STUB'
-#!/usr/bin/env bash
-set -euo pipefail
-
-state=${CODEX_BASPOWERS_CLAUDE_TEST_STATE:?}
-log=${CODEX_BASPOWERS_CLAUDE_TEST_LOG:?}
-legacy='super''powers'
-
-case "$*" in
-  "plugin marketplace list --json")
-    if [[ -e "$state/marketplace" ]]; then
-      printf '[{"name":"baspowers-dev"}]\n'
-    else
-      printf '[]\n'
-    fi
-    ;;
-  "plugin marketplace add "*)
-    printf '%s\n' "$*" >>"$log"
-    touch "$state/marketplace"
-    ;;
-  "plugin marketplace remove baspowers-dev")
-    printf '%s\n' "$*" >>"$log"
-    rm -f "$state/marketplace"
-    ;;
-  "plugin list --json")
-    printf '['
-    sep=
-    if [[ ! -e "$state/official_removed" ]]; then
-      printf '{"id":"%s@claude-plugins-official"}' "$legacy"
-      sep=,
-    fi
-    if [[ -e "$state/local" ]]; then
-      printf '%s{"id":"baspowers@baspowers-dev"}' "$sep"
-    fi
-    printf ']\n'
-    ;;
-  "plugin install baspowers@baspowers-dev")
-    printf '%s\n' "$*" >>"$log"
-    if [[ -e "$state/fail_local_add" ]]; then
-      exit 1
-    fi
-    touch "$state/local"
-    ;;
-  "plugin install ${legacy}@claude-plugins-official")
-    printf '%s\n' "$*" >>"$log"
-    rm -f "$state/official_removed"
-    ;;
-  "plugin uninstall ${legacy}@claude-plugins-official")
-    printf '%s\n' "$*" >>"$log"
-    touch "$state/official_removed"
-    ;;
-  "plugin uninstall baspowers@baspowers-dev")
-    printf '%s\n' "$*" >>"$log"
-    rm -f "$state/local"
-    ;;
-  *)
-    printf 'unexpected claude invocation: %s\n' "$*" >&2
-    exit 2
-    ;;
-esac
-STUB
-chmod +x "$claude_stub"
-
-export CODEX_BASPOWERS_CODEX_BIN="$stub"
-export CODEX_BASPOWERS_TEST_STATE="$state"
-export CODEX_BASPOWERS_TEST_LOG="$log"
-export CODEX_BASPOWERS_CLAUDE_BIN="$claude_stub"
-export CODEX_BASPOWERS_CLAUDE_TEST_STATE="$claude_state"
-export CODEX_BASPOWERS_CLAUDE_TEST_LOG="$claude_log"
+export BASPOWERS_CODEX_BIN="$test_root/codex"
+export BASPOWERS_CLAUDE_BIN="$test_root/claude"
+export BASPOWERS_TEST_LOG="$log"
 
 bash "$script"
 
 expected=$(cat <<EOF
-plugin marketplace add $repo_root/submodules/baspowers
-plugin add baspowers@baspowers-dev
-plugin remove ${legacy}@openai-curated
+codex plugin remove baspowers@baspowers-dev
+codex plugin marketplace remove baspowers-dev
+codex plugin marketplace add $repo_root/submodules/baspowers
+codex plugin add baspowers@baspowers-dev
+codex plugin list --json
+codex plugin remove ${legacy}@${legacy}-dev
+codex plugin marketplace remove ${legacy}-dev
+codex plugin remove ${legacy}@openai-curated
+claude plugin uninstall baspowers@baspowers-dev
+claude plugin marketplace remove baspowers-dev
+claude plugin marketplace add $repo_root/submodules/baspowers
+claude plugin install baspowers@baspowers-dev
+claude plugin list --json
+claude plugin uninstall ${legacy}@${legacy}-dev
+claude plugin marketplace remove ${legacy}-dev
+claude plugin uninstall ${legacy}@claude-plugins-official
 EOF
 )
-actual=$(cat "$log")
-[[ "$actual" == "$expected" ]]
-claude_expected=$(cat <<EOF
-plugin marketplace add $repo_root/submodules/baspowers
-plugin install baspowers@baspowers-dev
-plugin uninstall ${legacy}@claude-plugins-official
-EOF
-)
-claude_actual=$(cat "$claude_log")
-[[ "$claude_actual" == "$claude_expected" ]]
+[[ $(cat "$log") == "$expected" ]]
 
 : >"$log"
-: >"$claude_log"
-bash "$script"
-expected=$(cat <<EOF
-plugin add ${legacy}@openai-curated
-plugin remove baspowers@baspowers-dev
-plugin marketplace remove baspowers-dev
-plugin marketplace add $repo_root/submodules/baspowers
-plugin add baspowers@baspowers-dev
-plugin remove ${legacy}@openai-curated
-EOF
-)
-actual=$(cat "$log")
-[[ "$actual" == "$expected" ]]
-claude_expected=$(cat <<EOF
-plugin install ${legacy}@claude-plugins-official
-plugin uninstall baspowers@baspowers-dev
-plugin marketplace remove baspowers-dev
-plugin marketplace add $repo_root/submodules/baspowers
-plugin install baspowers@baspowers-dev
-plugin uninstall ${legacy}@claude-plugins-official
-EOF
-)
-claude_actual=$(cat "$claude_log")
-[[ "$claude_actual" == "$claude_expected" ]]
-
-touch "$state/fail_local_add"
+touch "$test_root/missing"
+export BASPOWERS_TEST_MISSING="$test_root/missing"
 if bash "$script"; then
-  printf 'sync unexpectedly succeeded when local plugin add failed\n' >&2
+  printf 'sync unexpectedly accepted a missing Codex plugin\n' >&2
   exit 1
 fi
-[[ ! -e "$state/official_removed" ]]
 
 printf 'sync-baspowers tests passed\n'

--- a/tests/test-sync-baspowers.sh
+++ b/tests/test-sync-baspowers.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script="$repo_root/scripts/sync-baspowers.sh"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+stub="$test_root/codex"
+state="$test_root/state"
+log="$test_root/mutations.log"
+claude_stub="$test_root/claude"
+claude_state="$test_root/claude-state"
+claude_log="$test_root/claude-mutations.log"
+mkdir -p "$state" "$claude_state"
+legacy='super''powers'
+
+cat >"$stub" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state=${CODEX_BASPOWERS_TEST_STATE:?}
+log=${CODEX_BASPOWERS_TEST_LOG:?}
+legacy='super''powers'
+
+case "$*" in
+  "plugin marketplace list --json")
+    if [[ -e "$state/marketplace" ]]; then
+      printf '{"marketplaces":[{"name":"baspowers-dev"}]}\n'
+    else
+      printf '{"marketplaces":[]}\n'
+    fi
+    ;;
+  "plugin marketplace add "*)
+    printf '%s\n' "$*" >>"$log"
+    touch "$state/marketplace"
+    ;;
+  "plugin marketplace remove baspowers-dev")
+    printf '%s\n' "$*" >>"$log"
+    rm -f "$state/marketplace"
+    ;;
+  "plugin list --json")
+    printf '{"installed":['
+    sep=
+    if [[ ! -e "$state/official_removed" ]]; then
+      printf '{"pluginId":"%s@openai-curated"}' "$legacy"
+      sep=,
+    fi
+    if [[ -e "$state/local" ]]; then
+      printf '%s{"pluginId":"baspowers@baspowers-dev"}' "$sep"
+    fi
+    printf ']}\n'
+    ;;
+  "plugin add baspowers@baspowers-dev")
+    printf '%s\n' "$*" >>"$log"
+    if [[ -e "$state/fail_local_add" ]]; then
+      exit 1
+    fi
+    touch "$state/local"
+    ;;
+  "plugin add ${legacy}@openai-curated")
+    printf '%s\n' "$*" >>"$log"
+    rm -f "$state/official_removed"
+    ;;
+  "plugin remove ${legacy}@openai-curated")
+    printf '%s\n' "$*" >>"$log"
+    touch "$state/official_removed"
+    ;;
+  "plugin remove baspowers@baspowers-dev")
+    printf '%s\n' "$*" >>"$log"
+    rm -f "$state/local"
+    ;;
+  *)
+    printf 'unexpected codex invocation: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+STUB
+chmod +x "$stub"
+
+cat >"$claude_stub" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state=${CODEX_BASPOWERS_CLAUDE_TEST_STATE:?}
+log=${CODEX_BASPOWERS_CLAUDE_TEST_LOG:?}
+legacy='super''powers'
+
+case "$*" in
+  "plugin marketplace list --json")
+    if [[ -e "$state/marketplace" ]]; then
+      printf '[{"name":"baspowers-dev"}]\n'
+    else
+      printf '[]\n'
+    fi
+    ;;
+  "plugin marketplace add "*)
+    printf '%s\n' "$*" >>"$log"
+    touch "$state/marketplace"
+    ;;
+  "plugin marketplace remove baspowers-dev")
+    printf '%s\n' "$*" >>"$log"
+    rm -f "$state/marketplace"
+    ;;
+  "plugin list --json")
+    printf '['
+    sep=
+    if [[ ! -e "$state/official_removed" ]]; then
+      printf '{"id":"%s@claude-plugins-official"}' "$legacy"
+      sep=,
+    fi
+    if [[ -e "$state/local" ]]; then
+      printf '%s{"id":"baspowers@baspowers-dev"}' "$sep"
+    fi
+    printf ']\n'
+    ;;
+  "plugin install baspowers@baspowers-dev")
+    printf '%s\n' "$*" >>"$log"
+    if [[ -e "$state/fail_local_add" ]]; then
+      exit 1
+    fi
+    touch "$state/local"
+    ;;
+  "plugin install ${legacy}@claude-plugins-official")
+    printf '%s\n' "$*" >>"$log"
+    rm -f "$state/official_removed"
+    ;;
+  "plugin uninstall ${legacy}@claude-plugins-official")
+    printf '%s\n' "$*" >>"$log"
+    touch "$state/official_removed"
+    ;;
+  "plugin uninstall baspowers@baspowers-dev")
+    printf '%s\n' "$*" >>"$log"
+    rm -f "$state/local"
+    ;;
+  *)
+    printf 'unexpected claude invocation: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+STUB
+chmod +x "$claude_stub"
+
+export CODEX_BASPOWERS_CODEX_BIN="$stub"
+export CODEX_BASPOWERS_TEST_STATE="$state"
+export CODEX_BASPOWERS_TEST_LOG="$log"
+export CODEX_BASPOWERS_CLAUDE_BIN="$claude_stub"
+export CODEX_BASPOWERS_CLAUDE_TEST_STATE="$claude_state"
+export CODEX_BASPOWERS_CLAUDE_TEST_LOG="$claude_log"
+
+bash "$script"
+
+expected=$(cat <<EOF
+plugin marketplace add $repo_root/submodules/baspowers
+plugin add baspowers@baspowers-dev
+plugin remove ${legacy}@openai-curated
+EOF
+)
+actual=$(cat "$log")
+[[ "$actual" == "$expected" ]]
+claude_expected=$(cat <<EOF
+plugin marketplace add $repo_root/submodules/baspowers
+plugin install baspowers@baspowers-dev
+plugin uninstall ${legacy}@claude-plugins-official
+EOF
+)
+claude_actual=$(cat "$claude_log")
+[[ "$claude_actual" == "$claude_expected" ]]
+
+: >"$log"
+: >"$claude_log"
+bash "$script"
+expected=$(cat <<EOF
+plugin add ${legacy}@openai-curated
+plugin remove baspowers@baspowers-dev
+plugin marketplace remove baspowers-dev
+plugin marketplace add $repo_root/submodules/baspowers
+plugin add baspowers@baspowers-dev
+plugin remove ${legacy}@openai-curated
+EOF
+)
+actual=$(cat "$log")
+[[ "$actual" == "$expected" ]]
+claude_expected=$(cat <<EOF
+plugin install ${legacy}@claude-plugins-official
+plugin uninstall baspowers@baspowers-dev
+plugin marketplace remove baspowers-dev
+plugin marketplace add $repo_root/submodules/baspowers
+plugin install baspowers@baspowers-dev
+plugin uninstall ${legacy}@claude-plugins-official
+EOF
+)
+claude_actual=$(cat "$claude_log")
+[[ "$claude_actual" == "$claude_expected" ]]
+
+touch "$state/fail_local_add"
+if bash "$script"; then
+  printf 'sync unexpectedly succeeded when local plugin add failed\n' >&2
+  exit 1
+fi
+[[ ! -e "$state/official_removed" ]]
+
+printf 'sync-baspowers tests passed\n'


### PR DESCRIPTION
## Summary

- track `basnijholt/baspowers` as a branch-pinned submodule
- install the local fork globally for Codex and Claude
- make `configs/codex/AGENTS.md` canonical for both Codex config locations
- retain the full Baspowers workflow while replacing routine approval gates with autonomous decisions
- consult the opposite model through `agent-cli dev` for hard technical ambiguity
- preserve a working fallback while either local plugin refreshes

## Validation

- `bash tests/test-sync-baspowers.sh`
- `bash tests/test-baspowers-brand.sh`
- fork autonomous-workflow and branding regression tests
- fork shell, manifest, package, sync, workspace, debugging, Hermes, Pi, hooks, and brainstorm-server tests
- fresh read-only Codex session from an unrelated repository loaded the customized workflow