### PR TITLE
Repair fleet dotfiles installation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,32 +1,32 @@
 [submodule "submodules/rsync-time-backup"]
 	path = submodules/rsync-time-backup
-	url = git@github.com:basnijholt/backups.git
+	url = https://github.com/basnijholt/backups.git
 [submodule "submodules/dotbot"]
 	path = submodules/dotbot
 	url = https://github.com/anishathalye/dotbot
 	ignore = dirty
 [submodule "submodules/truenas-zfs-unlock"]
 	path = submodules/truenas-zfs-unlock
-	url = git@github.com:ThorpeJosh/truenas-zfs-unlock.git
+	url = https://github.com/ThorpeJosh/truenas-zfs-unlock.git
 [submodule "submodules/dotbins"]
 	path = submodules/dotbins
-	url = git@github.com:basnijholt/dotbins.git
+	url = https://github.com/basnijholt/dotbins.git
 [submodule "submodules/mydotbins"]
 	path = submodules/mydotbins
-	url = git@github.com:basnijholt/mydotbins.git
+	url = https://github.com/basnijholt/mydotbins.git
 [submodule "submodules/oh-my-zsh"]
 	path = submodules/oh-my-zsh
-	url = git@github.com:robbyrussell/oh-my-zsh.git
+	url = https://github.com/robbyrussell/oh-my-zsh.git
 	ignore = dirty
 [submodule "submodules/zsh-syntax-highlighting"]
 	path = submodules/zsh-syntax-highlighting
-	url = git@github.com:zsh-users/zsh-syntax-highlighting.git
+	url = https://github.com/zsh-users/zsh-syntax-highlighting.git
 [submodule "submodules/zsh-autosuggestions"]
 	path = submodules/zsh-autosuggestions
-	url = git@github.com:zsh-users/zsh-autosuggestions.git
+	url = https://github.com/zsh-users/zsh-autosuggestions.git
 [submodule "submodules/syncthing-resolve-conflicts"]
 	path = submodules/syncthing-resolve-conflicts
-	url = git@github.com:dschrempf/syncthing-resolve-conflicts.git
+	url = https://github.com/dschrempf/syncthing-resolve-conflicts.git
 [submodule "submodules/tmux"]
 	path = submodules/tmux
 	url = https://github.com/gpakosz/.tmux.git

--- a/docs/superpowers/plans/2026-08-30-fleet-install-repair.md
+++ b/docs/superpowers/plans/2026-08-30-fleet-install-repair.md
@@ -185,11 +185,11 @@ Move both `submodules/mydotbins` and `.git/modules/submodules/mydotbins` into a 
 
 - [ ] **Step 5: Repair user-owned package state**
 
-On `pc`, list and validate every root-owned entry under `~/.local/share/uv/tools` and `~/.codex/tmp/arg0`, then use sudo to change only those entries to `basnijholt:users`. On `nas`, remove only the obsolete broken `truenas-unlock` UV tool and verify desired `zfs-unlock` installs successfully.
+On `pc`, list and validate every root-owned entry under `~/.local/share/uv/tools` and `~/.codex/tmp/arg0`. If sudo is unavailable, move only affected top-level UV environments into persistent recovery and recreate desired tools as the user. Preserve inaccessible Codex temp artifacts and prove fresh Codex and Claude plugin operations succeed despite cleanup warnings. On `nas`, remove only the obsolete broken `truenas-unlock` UV tool and verify desired `zfs-unlock` installs successfully.
 
 - [ ] **Step 6: Verify host-local invariants**
 
-Confirm no commits were created on `gce-vm` or `mindroom`, their indexes have no unmerged entries, remote recovery backups exist, and public remotes resolve through HTTPS.
+Confirm no commits were created on `gce-vm` or `mindroom`, their indexes have no unmerged entries, remote recovery backups exist, public remotes resolve through HTTPS, and `pc`'s UV and plugin operations succeed. Report any preserved inaccessible Codex temp artifacts explicitly.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-30-fleet-install-repair.md
+++ b/docs/superpowers/plans/2026-08-30-fleet-install-repair.md
@@ -164,8 +164,8 @@ Run `git status --short`, stage only `scripts/sync-secrets.sh` and `tests/test-s
 - No repository files. Mutate only explicitly identified remote Git metadata, conflict paths, ownership entries, and recovery directories.
 
 **Interfaces:**
-- Consumes: merged repository changes from Tasks 1-3.
-- Produces: reachable hosts able to run the shared installer while retaining their local work.
+- Consumes: the diagnostic evidence and current pinned Git revisions recorded in the spec.
+- Produces: reachable hosts with repaired local state, ready to consume Tasks 1-3 after Task 5 merges them.
 
 - [ ] **Step 1: Resolve `gce-vm` without committing**
 

--- a/docs/superpowers/plans/2026-08-30-fleet-install-repair.md
+++ b/docs/superpowers/plans/2026-08-30-fleet-install-repair.md
@@ -1,0 +1,223 @@
+# Fleet Install Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make fleet installation reliable on every reachable host without losing or committing host-local work.
+
+**Architecture:** Harden the shared repository scripts first, merge them through review, then repair exceptional remote state and rerun the same fleet entrypoint. Public repositories use HTTPS; private secrets remain private and `pi4` receives only its ZFS-unlock-specific handling.
+
+**Tech Stack:** Bash, Git submodules, Dotbot YAML, SSH, UV, Bun, Codex and Claude plugin CLIs.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-fleet-install-repair-design.md`
+
+## Global Constraints
+
+- Never commit on `gce-vm` or `mindroom`.
+- Preserve host-local changes, retained autostashes, and corrupt Git state in persistent recovery locations.
+- Never use `git reset --hard`, force pushes, broad recursive deletion, or `git add -A`.
+- Never expose secret contents.
+- Do not modify `pi3` routing while it is unreachable at Layer 2.
+- Do not create branches beginning with `codex/`.
+- Run `git status` before staging and verify staged paths afterward.
+- Do not amend commits.
+
+---
+
+### Task 1: Normalize Public Submodule Transport
+
+**Files:**
+- Modify: `.gitmodules`
+- Create: `tests/test-submodule-urls.sh`
+
+**Interfaces:**
+- Consumes: Git's `.gitmodules` configuration parser.
+- Produces: HTTPS URLs consumed by `git submodule sync --recursive` on every host.
+
+- [ ] **Step 1: Write the failing transport regression test**
+
+Create a Bash test that runs `git config -f .gitmodules --get-regexp '^submodule\..*\.url$'`, fails if any value begins with `git@github.com:`, and prints `submodule URL tests passed` otherwise.
+
+- [ ] **Step 2: Verify the transport test fails**
+
+Run: `bash tests/test-submodule-urls.sh`
+
+Expected: nonzero with the existing SSH-backed public submodule names.
+
+- [ ] **Step 3: Convert verified-public GitHub URLs to HTTPS**
+
+Use these exact repository mappings:
+
+```text
+basnijholt/backups                    https://github.com/basnijholt/backups.git
+basnijholt/dotbins                    https://github.com/basnijholt/dotbins.git
+basnijholt/mydotbins                  https://github.com/basnijholt/mydotbins.git
+robbyrussell/oh-my-zsh                https://github.com/robbyrussell/oh-my-zsh.git
+dschrempf/syncthing-resolve-conflicts https://github.com/dschrempf/syncthing-resolve-conflicts.git
+ThorpeJosh/truenas-zfs-unlock         https://github.com/ThorpeJosh/truenas-zfs-unlock.git
+zsh-users/zsh-autosuggestions         https://github.com/zsh-users/zsh-autosuggestions.git
+zsh-users/zsh-syntax-highlighting     https://github.com/zsh-users/zsh-syntax-highlighting.git
+```
+
+- [ ] **Step 4: Verify the transport test and remote access**
+
+Run the test, `git diff --check`, and `git ls-remote --exit-code <url> HEAD` for every changed URL. Expected: all exit zero.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run `git status --short`, stage only `.gitmodules` and `tests/test-submodule-urls.sh`, inspect `git diff --cached`, and commit with `fix(sync): use HTTPS for public submodules`.
+
+---
+
+### Task 2: Harden Tool Synchronization
+
+**Files:**
+- Modify: `scripts/sync-uv.sh`
+- Modify: `scripts/sync-bun.sh`
+- Modify: `scripts/sync-baspowers.sh`
+- Modify: `install.conf.yaml`
+- Create: `tests/test-sync-uv.sh`
+- Create: `tests/test-sync-bun.sh`
+- Modify: `tests/test-sync-baspowers.sh`
+
+**Interfaces:**
+- Consumes: `${DOTBINS_SHELL:-$HOME/.dotbins/shell/bash.sh}`, `${BUN_INSTALL:-$HOME/.bun}`, Bun global T3 installation, and Codex/Claude CLIs.
+- Produces: noninteractive installers that expose failures and resolve Bun-installed executables consistently.
+
+- [ ] **Step 1: Write failing UV and Bun behavior tests**
+
+The UV test must execute `sync-uv.sh` with a controlled Dotbins shell and fake `uv`, proving any failed parallel install makes the script return nonzero and the success path reaches `uv tool upgrade --all`.
+
+The Bun test must execute `sync-bun.sh` with controlled `DOTBINS_SHELL` and `BUN_INSTALL`, prove the Bun bin directory is used, emulate Node resolving a hoisted `node-pty`, and assert `node-gyp rebuild` runs from that resolved directory. It must fail if a package install or rebuild fails.
+
+Extend the Baspowers test with a no-override case where Codex and Claude resolve only through `${BUN_INSTALL}/bin`.
+
+- [ ] **Step 2: Verify all new behavior tests fail for the intended missing behavior**
+
+Run each test separately. Expected: failures identify masked errors, missing Bun PATH, or the hard-coded nested `node-pty` path—not test setup errors.
+
+- [ ] **Step 3: Implement minimal fail-fast and PATH handling**
+
+Add `set -euo pipefail` to UV and Bun scripts. Source `${DOTBINS_SHELL:-$HOME/.dotbins/shell/bash.sh}`. In Bun and Baspowers scripts use:
+
+```bash
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+```
+
+Keep Baspowers' explicit `BASPOWERS_CODEX_BIN` and `BASPOWERS_CLAUDE_BIN` overrides authoritative.
+
+- [ ] **Step 4: Resolve `node-pty` dynamically**
+
+After installing T3 and node-gyp, resolve `node-pty/package.json` with Node relative to `$BUN_INSTALL/install/global/node_modules/t3`, take its directory, change into it, and run `"$BUN_INSTALL/bin/node-gyp" rebuild`. Fail clearly if resolution fails.
+
+- [ ] **Step 5: Expose Dotbot command output**
+
+Convert each synchronization shell entry in `install.conf.yaml` to mapping form with `command`, `stdout: true`, and `stderr: true`, retaining command order.
+
+- [ ] **Step 6: Verify all installer tests**
+
+Run all files under `tests/test-sync-*.sh`, Bash syntax checks for changed scripts/tests, and `git diff --check`. Expected: all exit zero.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run `git status --short`, stage only Task 2 files, inspect staged paths/diff, and commit with `fix(install): harden noninteractive tool sync`.
+
+---
+
+### Task 3: Limit Pi 4 Secrets Installation
+
+**Files:**
+- Modify: `scripts/sync-secrets.sh`
+- Create: `tests/test-sync-secrets.sh`
+
+**Interfaces:**
+- Consumes: `SYNC_SECRETS_HOSTNAME` for tests, `DOTFILES_ROOT`, optional `SECRETS_DIR`, and optional `ZFS_UNLOCK_CONFIG_TARGET`.
+- Produces: generic secrets installation for workstation hosts and ZFS-unlock-only validation/linking for `pi4`.
+
+- [ ] **Step 1: Write the failing Pi 4 secrets test**
+
+Execute the real script with a controlled secrets checkout and Git boundary. Create the six required decrypted files, omit workstation-only files, and make the generic secrets installer write a marker if invoked. Assert `pi4` succeeds without that marker, preserves an existing config target, and creates a symlink when the target is absent. Add a missing-required-key case that returns nonzero without printing secret content.
+
+- [ ] **Step 2: Verify the test fails for the generic installer behavior**
+
+Run: `bash tests/test-sync-secrets.sh`
+
+Expected: nonzero because the current script invokes the generic installer on `pi4`.
+
+- [ ] **Step 3: Implement the Pi 4-specific path**
+
+Allow `SYNC_SECRETS_HOSTNAME`, `SECRETS_DIR`, and `ZFS_UNLOCK_CONFIG_TARGET` overrides with production-safe defaults. After updating the checkout, validate the exact six files from the spec. Preserve an existing target; otherwise create its parent and symlink it to `configs/zfs-unlock/config.yaml`. Return without invoking `secrets/install` on `pi4`.
+
+- [ ] **Step 4: Verify secrets behavior and full shell suite**
+
+Run the new test, all existing shell tests, Bash syntax checks, and `git diff --check`. Expected: all exit zero and no secret contents appear.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run `git status --short`, stage only `scripts/sync-secrets.sh` and `tests/test-sync-secrets.sh`, inspect the staged diff, and commit with `fix(secrets): limit pi4 install to zfs unlock`.
+
+---
+
+### Task 4: Repair Host-Local State
+
+**Files:**
+- No repository files. Mutate only explicitly identified remote Git metadata, conflict paths, ownership entries, and recovery directories.
+
+**Interfaces:**
+- Consumes: merged repository changes from Tasks 1-3.
+- Produces: reachable hosts able to run the shared installer while retaining their local work.
+
+- [ ] **Step 1: Resolve `gce-vm` without committing**
+
+Take the current upstream version of `configs/codex/AGENTS.md`, verify conflict markers are absent, run `git diff --check` for that path, and stage only it. Confirm no merge/rebase/cherry-pick is active, retain the autostash, and do not commit.
+
+- [ ] **Step 2: Resolve `mindroom` without committing**
+
+Preserve the current combined `configs/claude/settings.json`, add top-level `"alwaysThinkingEnabled": false` before `effortLevel`, validate with `jq`, verify no conflict markers, and stage only that path. Retain all other changes and the autostash; do not commit.
+
+- [ ] **Step 3: Repair public top-level origins**
+
+On `docker-lxc` and `hetzner`, set origin to `https://github.com/basnijholt/dotfiles.git`, verify `ls-remote`, and let the shared `git pull --autostash` preserve local modifications.
+
+- [ ] **Step 4: Rebuild corrupt `nix-cache` submodule reversibly**
+
+Move both `submodules/mydotbins` and `.git/modules/submodules/mydotbins` into a timestamped directory under `~/dotfiles-recovery/`, set its cached URL to HTTPS, reinitialize the submodule, run `git fsck --full`, and verify HEAD equals `91e1b88bb9d47358c965c6118a33e77a56e5419d`.
+
+- [ ] **Step 5: Repair user-owned package state**
+
+On `pc`, list and validate every root-owned entry under `~/.local/share/uv/tools` and `~/.codex/tmp/arg0`, then use sudo to change only those entries to `basnijholt:users`. On `nas`, remove only the obsolete broken `truenas-unlock` UV tool and verify desired `zfs-unlock` installs successfully.
+
+- [ ] **Step 6: Verify host-local invariants**
+
+Confirm no commits were created on `gce-vm` or `mindroom`, their indexes have no unmerged entries, remote recovery backups exist, and public remotes resolve through HTTPS.
+
+---
+
+### Task 5: Review, Merge, and Fleet Rollout
+
+**Files:**
+- No new repository files beyond review fixes.
+
+**Interfaces:**
+- Consumes: reviewed commits from Tasks 1-3 and repaired host state from Task 4.
+- Produces: merged `main` and a verified fleet install summary.
+
+- [ ] **Step 1: Run final repository verification**
+
+Run every `tests/test-*.sh`, Bash syntax checks for all shell scripts/tests, `git diff --check`, and HTTPS `ls-remote` checks. Expected: all exit zero.
+
+- [ ] **Step 2: Open a normal PR**
+
+Push `bas/fix-fleet-install`, open a non-draft PR against `main`, keep the description repository-relative, wait for AI review, validate every finding, and address valid findings without amending commits.
+
+- [ ] **Step 3: Merge reviewed changes**
+
+Merge only after checks and review are clean. Do not force push.
+
+- [ ] **Step 4: Run the fleet install**
+
+From the primary checkout on updated `main`, run `./scripts/sync-dotfiles.sh install` and retain the full exit status and per-host summary.
+
+- [ ] **Step 5: Verify each reachable host**
+
+Confirm the main commit, submodule states, and installer exit status on every reachable host. Report `pi3` separately if Layer-2 reachability is still unavailable; do not count it as a software repair failure.

--- a/docs/superpowers/specs/2026-08-30-fleet-install-repair-design.md
+++ b/docs/superpowers/specs/2026-08-30-fleet-install-repair-design.md
@@ -1,0 +1,70 @@
+# Fleet Install Repair Design
+
+## Goal
+
+Make `scripts/sync-dotfiles.sh install` succeed on every reachable fleet host while preserving host-local work, eliminating avoidable SSH transport dependencies, and reporting real failures.
+
+## Current failure domains
+
+1. Public GitHub repositories still use SSH URLs on hosts without trusted host keys or private keys.
+2. `sync-bun.sh` and `sync-baspowers.sh` assume interactive-shell PATH setup, so `node-gyp`, `codex`, and `claude` are invisible over noninteractive SSH.
+3. `sync-bun.sh` assumes `node-pty` is nested below T3, but Bun may hoist it to the global package root.
+4. `sync-uv.sh` and `sync-bun.sh` can hide earlier command failures.
+5. The generic secrets installer treats workstation-only secrets as mandatory on `pi4`, although `pi4` only needs its existing ZFS-unlock material.
+6. `gce-vm` and `mindroom` have failed autostash reapplications; their local changes must remain uncommitted.
+7. `nix-cache` has a corrupt `mydotbins` object database; `pc` has root-owned UV/Codex state; `nas` has an obsolete broken UV tool.
+8. `pi3` is offline at the network layer and cannot be repaired remotely until it is reachable.
+
+## Repository changes
+
+### Git transport
+
+Use HTTPS for every public GitHub submodule in `.gitmodules`. Keep private secrets handling unchanged. `git submodule sync --recursive` remains before updates so existing cached URLs migrate automatically.
+
+### Tool installers
+
+- `sync-uv.sh` and `sync-bun.sh` fail immediately on errors.
+- `sync-bun.sh` exports `${BUN_INSTALL:-$HOME/.bun}/bin` before invoking Bun-installed tools.
+- `sync-bun.sh` asks Node to resolve `node-pty/package.json` relative to the installed T3 package, supporting nested and hoisted layouts, then invokes the explicit Bun-installed `node-gyp`.
+- `sync-baspowers.sh` exports the same Bun bin directory before resolving default Codex and Claude executables.
+- Dotbot exposes stdout and stderr for each synchronization command.
+
+### Pi 4 secrets
+
+`sync-secrets.sh` continues updating the private checkout on `pi4`, validates the required decrypted ZFS-unlock config and key files, and preserves any existing user config. If the config target is absent, it creates a symlink to the decrypted config. It does not run the generic workstation secrets installer on `pi4`.
+
+Required Pi 4 files are:
+
+- `configs/zfs-unlock/config.yaml`
+- `configs/zfs-unlock/frigate_key`
+- `configs/zfs-unlock/photos_export_key`
+- `configs/zfs-unlock/photos_key`
+- `configs/zfs-unlock/stash_key`
+- `configs/zfs-unlock/zfs-unlock-receiver`
+
+## Host-local repairs
+
+- Resolve `gce-vm`'s `configs/codex/AGENTS.md` with the current upstream version and stage only that path. Do not commit or drop the retained autostash.
+- Resolve `mindroom`'s `configs/claude/settings.json` by preserving the combined worktree plus `"alwaysThinkingEnabled": false`, then stage only that path. Do not commit or drop the retained autostash.
+- Change the public top-level origins on `docker-lxc` and `hetzner` to HTTPS, preserving local modifications through autostash.
+- Move the corrupt `nix-cache` `mydotbins` worktree and gitdir into a persistent recovery directory, then reinitialize from HTTPS and verify it with `git fsck`.
+- Correct only root-owned UV/Codex entries under the affected `pc` user directories; do not delete entire tool trees.
+- Remove the obsolete broken `truenas-unlock` UV tool on `nas`; the desired replacement is `zfs-unlock`.
+- Let the repository-wide HTTPS migration repair `hetzner-saas` and future public submodule fetches.
+
+## Safety constraints
+
+- Never commit on `gce-vm` or `mindroom`.
+- Never discard host-local changes, retained autostashes, or corrupt Git state; preserve recoverable backups.
+- Never use `git reset --hard`, force pushes, broad recursive deletion, or `git add -A`.
+- Never expose secret contents in logs, tests, commits, or review descriptions.
+- Do not modify `pi3` routing; report it as externally blocked until Layer-2 reachability returns.
+- Keep repository changes minimal and test shell behavior through controlled command boundaries.
+
+## Verification
+
+1. Every new regression test is observed failing before its implementation and passing after it.
+2. All shell tests, syntax checks, and `git diff --check` pass.
+3. A normal PR receives review; valid findings are addressed before merge.
+4. The fleet install is rerun after central changes land.
+5. Each reachable host is reported independently, with `pi3` explicitly identified as an external availability blocker if still offline.

--- a/docs/superpowers/specs/2026-08-30-fleet-install-repair-design.md
+++ b/docs/superpowers/specs/2026-08-30-fleet-install-repair-design.md
@@ -48,14 +48,14 @@ Required Pi 4 files are:
 - Resolve `mindroom`'s `configs/claude/settings.json` by preserving the combined worktree plus `"alwaysThinkingEnabled": false`, then stage only that path. Do not commit or drop the retained autostash.
 - Change the public top-level origins on `docker-lxc` and `hetzner` to HTTPS, preserving local modifications through autostash.
 - Move the corrupt `nix-cache` `mydotbins` worktree and gitdir into a persistent recovery directory, then reinitialize from HTTPS and verify it with `git fsck`.
-- Correct only root-owned UV/Codex entries under the affected `pc` user directories; do not delete entire tool trees.
+- Recover root-owned UV environments on `pc` into persistent storage and recreate desired tools as the user. Root-owned Codex temp artifacts may remain preserved when privilege is unavailable if fresh Codex and Claude plugin operations succeed; they are cleanup noise, not plugin state.
 - Remove the obsolete broken `truenas-unlock` UV tool on `nas`; the desired replacement is `zfs-unlock`.
 - Let the repository-wide HTTPS migration repair `hetzner-saas` and future public submodule fetches.
 
 ## Safety constraints
 
 - Never commit on `gce-vm` or `mindroom`.
-- Never discard host-local changes, retained autostashes, or corrupt Git state; preserve recoverable backups.
+- Never discard host-local changes, retained autostashes, corrupt Git state, or inaccessible root-owned temp artifacts; preserve recoverable backups.
 - Never use `git reset --hard`, force pushes, broad recursive deletion, or `git add -A`.
 - Never expose secret contents in logs, tests, commits, or review descriptions.
 - Do not modify `pi3` routing; report it as externally blocked until Layer-2 reachability returns.

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -85,7 +85,7 @@
   - command: bash scripts/sync-secrets.sh
     stdout: true
     stderr: true
-  - command: git submodule update --init --recursive
+  - command: git submodule sync --recursive && git submodule update --init --recursive
     stdout: true
     stderr: true
   - command: bash scripts/sync-baspowers.sh

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -73,13 +73,24 @@
     ~/dotfiles/submodules/oh-my-zsh/themes/mytheme.zsh-theme: configs/zsh/mytheme.zsh-theme
 
 - shell:
-  - bash scripts/sync-uv.sh
-  - bash scripts/sync-bun.sh
-  - bash scripts/install-nano-syntax.sh
+  - command: bash scripts/sync-uv.sh
+    stdout: true
+    stderr: true
+  - command: bash scripts/sync-bun.sh
+    stdout: true
+    stderr: true
+  - command: bash scripts/install-nano-syntax.sh
+    stdout: true
+    stderr: true
   - command: bash scripts/sync-secrets.sh
     stdout: true
-  - git submodule update --init --recursive
-  - bash scripts/sync-baspowers.sh
+    stderr: true
+  - command: git submodule update --init --recursive
+    stdout: true
+    stderr: true
+  - command: bash scripts/sync-baspowers.sh
+    stdout: true
+    stderr: true
 
 # -- Only on Linux --
 - defaults:

--- a/scripts/sync-baspowers.sh
+++ b/scripts/sync-baspowers.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 plugin_root="$repo_root/submodules/baspowers"
 codex_bin=${BASPOWERS_CODEX_BIN:-codex}

--- a/scripts/sync-bun.sh
+++ b/scripts/sync-bun.sh
@@ -22,7 +22,7 @@ bun install -g "${packages[@]}"
 bun install -g node-gyp@latest
 node_pty_package=''
 t3_global_dir="$BUN_INSTALL/install/global/node_modules/t3"
-if ! node_pty_package=$(cd "$t3_global_dir" && "$BUN_INSTALL/bin/node" -p 'require.resolve("node-pty/package.json")'); then
+if ! node_pty_package=$(cd "$t3_global_dir" && node -p 'require.resolve("node-pty/package.json")'); then
     printf 'Could not resolve node-pty from T3 global modules.\n' >&2
     exit 1
 fi

--- a/scripts/sync-bun.sh
+++ b/scripts/sync-bun.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # -- Dotbins: ensures bun is in the PATH
-source "$HOME/.dotbins/shell/bash.sh"
+source "${DOTBINS_SHELL:-$HOME/.dotbins/shell/bash.sh}"
+
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
 
 packages=(
     @google/gemini-cli@latest
@@ -16,7 +20,18 @@ bun install -g "${packages[@]}"
 
 # T3's node-pty dependency has no Linux prebuild, so build its native addon.
 bun install -g node-gyp@latest
+node_pty_package=''
+t3_global_dir="$BUN_INSTALL/install/global/node_modules/t3"
+if ! node_pty_package=$(cd "$t3_global_dir" && "$BUN_INSTALL/bin/node" -p 'require.resolve("node-pty/package.json")'); then
+    printf 'Could not resolve node-pty from T3 global modules.\n' >&2
+    exit 1
+fi
+node_pty_dir=$(dirname "$node_pty_package")
+if [[ ! -d "$node_pty_dir" ]]; then
+    printf 'Resolved node-pty directory does not exist: %s\n' "$node_pty_dir" >&2
+    exit 1
+fi
 (
-    cd "$HOME/.bun/install/global/node_modules/t3/node_modules/node-pty"
-    node-gyp rebuild
+    cd "$node_pty_dir"
+    "$BUN_INSTALL/bin/node-gyp" rebuild
 )

--- a/scripts/sync-secrets.sh
+++ b/scripts/sync-secrets.sh
@@ -54,8 +54,9 @@ if [[ "$HOSTNAME" == pi4 ]]; then
     fi
   done
 
-  if [[ ! -e "$ZFS_UNLOCK_CONFIG_TARGET" && ! -L "$ZFS_UNLOCK_CONFIG_TARGET" ]]; then
+  if [[ ! -e "$ZFS_UNLOCK_CONFIG_TARGET" ]]; then
     mkdir -p "$(dirname "$ZFS_UNLOCK_CONFIG_TARGET")"
+    rm -f "$ZFS_UNLOCK_CONFIG_TARGET"
     ln -s "$SECRETS_DIR/configs/zfs-unlock/config.yaml" "$ZFS_UNLOCK_CONFIG_TARGET"
   fi
 

--- a/scripts/sync-secrets.sh
+++ b/scripts/sync-secrets.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 DOTFILES_ROOT="${DOTFILES_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-SECRETS_DIR="$DOTFILES_ROOT/secrets"
+SECRETS_DIR="${SECRETS_DIR:-$DOTFILES_ROOT/secrets}"
 SECRETS_REPO_URL="${SECRETS_REPO_URL:-git@github.com:basnijholt/dotfiles-secrets.git}"
-HOSTNAME="$(hostname -s)"
+HOSTNAME="${SYNC_SECRETS_HOSTNAME:-$(hostname -s)}"
+ZFS_UNLOCK_CONFIG_TARGET="${ZFS_UNLOCK_CONFIG_TARGET:-$HOME/.config/zfs-unlock/config.yaml}"
 
 case "$HOSTNAME" in
   basnijholt-macbook-pro-2|basnijholt-macbook-pro|pc|pi4)
@@ -34,6 +35,31 @@ else
     git -C "$SECRETS_DIR" switch --create main --track origin/main
   fi
   git -C "$SECRETS_DIR" pull --ff-only origin main
+fi
+
+if [[ "$HOSTNAME" == pi4 ]]; then
+  required_zfs_unlock_files=(
+    configs/zfs-unlock/config.yaml
+    configs/zfs-unlock/frigate_key
+    configs/zfs-unlock/photos_export_key
+    configs/zfs-unlock/photos_key
+    configs/zfs-unlock/stash_key
+    configs/zfs-unlock/zfs-unlock-receiver
+  )
+
+  for required_file in "${required_zfs_unlock_files[@]}"; do
+    if [[ ! -f "$SECRETS_DIR/$required_file" ]]; then
+      printf 'Missing required ZFS-unlock secret file: %s\n' "$required_file" >&2
+      exit 1
+    fi
+  done
+
+  if [[ ! -e "$ZFS_UNLOCK_CONFIG_TARGET" && ! -L "$ZFS_UNLOCK_CONFIG_TARGET" ]]; then
+    mkdir -p "$(dirname "$ZFS_UNLOCK_CONFIG_TARGET")"
+    ln -s "$SECRETS_DIR/configs/zfs-unlock/config.yaml" "$ZFS_UNLOCK_CONFIG_TARGET"
+  fi
+
+  exit 0
 fi
 
 if [[ -f "$SECRETS_DIR/install" ]]; then

--- a/scripts/sync-uv.sh
+++ b/scripts/sync-uv.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # -- Dotbins: ensures uv is in the PATH
-source "$HOME/.dotbins/shell/bash.sh"
+source "${DOTBINS_SHELL:-$HOME/.dotbins/shell/bash.sh}"
 
 xargs -P4 -I{} sh -c 'uv tool install {}' << 'EOF'
 asciinema

--- a/tests/test-submodule-urls.sh
+++ b/tests/test-submodule-urls.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+while read -r name url; do
+  if [[ $url == git@github.com:* ]]; then
+    printf 'SSH transport is not allowed for %s: %s\n' "$name" "$url" >&2
+    exit 1
+  fi
+done < <(git -C "$repo_root" config -f .gitmodules --get-regexp '^submodule\..*\.url$')
+
+printf 'submodule URL tests passed\n'

--- a/tests/test-submodule-urls.sh
+++ b/tests/test-submodule-urls.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
 
 if ! urls=$(git -C "$repo_root" config -f .gitmodules --get-regexp '^submodule\..*\.url$'); then
   printf 'unable to parse .gitmodules\n' >&2
@@ -14,5 +16,54 @@ while read -r name url; do
     exit 1
   fi
 done <<<"$urls"
+
+submodule_remote="$test_root/submodule-remote.git"
+submodule_seed="$test_root/submodule-seed"
+superproject="$test_root/superproject"
+checkout="$test_root/checkout"
+
+git init --bare --initial-branch=main "$submodule_remote" >/dev/null
+git init --initial-branch=main "$submodule_seed" >/dev/null
+(
+  cd "$submodule_seed"
+  git config user.email test@example.invalid
+  git config user.name 'submodule URL test'
+  printf 'fixture\n' >fixture
+  git add fixture
+  git commit -m 'fixture submodule' >/dev/null
+  git remote add origin "$submodule_remote"
+  git push origin main >/dev/null
+)
+
+git init --initial-branch=main "$superproject" >/dev/null
+(
+  cd "$superproject"
+  git config user.email test@example.invalid
+  git config user.name 'submodule URL test'
+  git -c protocol.file.allow=always submodule add "$submodule_remote" modules/example >/dev/null
+  git commit -m 'fixture superproject' >/dev/null
+)
+git clone --no-recurse "$superproject" "$checkout" >/dev/null
+git -C "$checkout" submodule init >/dev/null
+git -C "$checkout" config submodule.modules/example.url "$test_root/stale-does-not-exist.git"
+
+submodule_command=$(awk '
+  /^[[:space:]]*- command: git submodule/ {
+    sub(/^[[:space:]]*- command: /, "")
+    print
+    exit
+  }
+' "$repo_root/install.conf.yaml")
+if [[ -z "$submodule_command" ]]; then
+  printf 'installer submodule action not found\n' >&2
+  exit 1
+fi
+if ! (
+  cd "$checkout"
+  GIT_ALLOW_PROTOCOL=file bash -c "$submodule_command"
+) >/dev/null 2>&1; then
+  printf 'installer did not migrate a stale cached submodule URL\n' >&2
+  exit 1
+fi
 
 printf 'submodule URL tests passed\n'

--- a/tests/test-submodule-urls.sh
+++ b/tests/test-submodule-urls.sh
@@ -3,11 +3,16 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
+if ! urls=$(git -C "$repo_root" config -f .gitmodules --get-regexp '^submodule\..*\.url$'); then
+  printf 'unable to parse .gitmodules\n' >&2
+  exit 1
+fi
+
 while read -r name url; do
   if [[ $url == git@github.com:* ]]; then
     printf 'SSH transport is not allowed for %s: %s\n' "$name" "$url" >&2
     exit 1
   fi
-done < <(git -C "$repo_root" config -f .gitmodules --get-regexp '^submodule\..*\.url$')
+done <<<"$urls"
 
 printf 'submodule URL tests passed\n'

--- a/tests/test-sync-baspowers.sh
+++ b/tests/test-sync-baspowers.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 script="$repo_root/scripts/sync-baspowers.sh"
+shell_bin=$(dirname "$(command -v bash)")
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 
@@ -34,7 +35,7 @@ export BASPOWERS_CODEX_BIN="$test_root/codex"
 export BASPOWERS_CLAUDE_BIN="$test_root/claude"
 export BASPOWERS_TEST_LOG="$log"
 
-bash "$script"
+bash "$script" >"$test_root/override-output" 2>&1
 
 expected=$(cat <<EOF
 codex plugin remove baspowers@baspowers-dev
@@ -58,9 +59,24 @@ EOF
 [[ $(cat "$log") == "$expected" ]]
 
 : >"$log"
+bun_install="$test_root/bun"
+mkdir -p "$bun_install/bin"
+ln -s "$stub" "$bun_install/bin/codex"
+ln -s "$stub" "$bun_install/bin/claude"
+if ! env -u BASPOWERS_CODEX_BIN -u BASPOWERS_CLAUDE_BIN \
+  BASPOWERS_TEST_LOG="$log" \
+  BUN_INSTALL="$bun_install" \
+  PATH="$shell_bin:/usr/bin:/bin" \
+  "$shell_bin/bash" "$script" >"$test_root/bun-install-output" 2>&1; then
+  printf 'sync-baspowers did not resolve Codex and Claude from BUN_INSTALL/bin\n' >&2
+  exit 1
+fi
+[[ $(head -n 1 "$log") == 'codex plugin remove baspowers@baspowers-dev' ]]
+
+: >"$log"
 touch "$test_root/missing"
 export BASPOWERS_TEST_MISSING="$test_root/missing"
-if bash "$script"; then
+if bash "$script" >"$test_root/missing-output" 2>&1; then
   printf 'sync unexpectedly accepted a missing Codex plugin\n' >&2
   exit 1
 fi

--- a/tests/test-sync-bun.sh
+++ b/tests/test-sync-bun.sh
@@ -8,14 +8,16 @@ test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 
 bun_install="$test_root/bun"
+command_bin="$test_root/commands"
 dotbins_shell="$test_root/dotbins-shell.sh"
 node_pty_dir="$test_root/hoisted/node-pty"
 t3_dir="$bun_install/install/global/node_modules/t3"
 log="$test_root/commands.log"
-mkdir -p "$bun_install/bin" "$node_pty_dir" "$t3_dir"
+mkdir -p "$bun_install/bin" "$command_bin" "$node_pty_dir" "$t3_dir"
 touch "$node_pty_dir/package.json"
 
 cat >"$dotbins_shell" <<'SHELL'
+export PATH="${SYNC_BUN_TEST_COMMAND_BIN:?}:$PATH"
 export SYNC_BUN_DOTBINS_SOURCED=1
 SHELL
 
@@ -30,7 +32,7 @@ if [[ "${SYNC_BUN_FAIL_INSTALL:-}" == 1 ]]; then
 fi
 BUN
 
-cat >"$bun_install/bin/node" <<'NODE'
+cat >"$command_bin/node" <<'NODE'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -47,13 +49,14 @@ if [[ "${SYNC_BUN_FAIL_REBUILD:-}" == 1 ]]; then
   exit 24
 fi
 NODE_GYP
-chmod +x "$bun_install/bin/bun" "$bun_install/bin/node" "$bun_install/bin/node-gyp"
+chmod +x "$bun_install/bin/bun" "$command_bin/node" "$bun_install/bin/node-gyp"
 
 run_sync() {
   env \
     BUN_INSTALL="$bun_install" \
     DOTBINS_SHELL="$dotbins_shell" \
     PATH="$shell_bin:/usr/bin:/bin" \
+    SYNC_BUN_TEST_COMMAND_BIN="$command_bin" \
     SYNC_BUN_NODE_PTY_PACKAGE="$node_pty_dir/package.json" \
     SYNC_BUN_TEST_LOG="$log" \
     "$@" \

--- a/tests/test-sync-bun.sh
+++ b/tests/test-sync-bun.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script="$repo_root/scripts/sync-bun.sh"
+shell_bin=$(dirname "$(command -v bash)")
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+bun_install="$test_root/bun"
+dotbins_shell="$test_root/dotbins-shell.sh"
+node_pty_dir="$test_root/hoisted/node-pty"
+t3_dir="$bun_install/install/global/node_modules/t3"
+log="$test_root/commands.log"
+mkdir -p "$bun_install/bin" "$node_pty_dir" "$t3_dir"
+touch "$node_pty_dir/package.json"
+
+cat >"$dotbins_shell" <<'SHELL'
+export SYNC_BUN_DOTBINS_SOURCED=1
+SHELL
+
+cat >"$bun_install/bin/bun" <<'BUN'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${SYNC_BUN_DOTBINS_SOURCED:-}" == 1 ]]
+printf 'bun %s\n' "$*" >>"${SYNC_BUN_TEST_LOG:?}"
+if [[ "${SYNC_BUN_FAIL_INSTALL:-}" == 1 ]]; then
+  exit 23
+fi
+BUN
+
+cat >"$bun_install/bin/node" <<'NODE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'node %s cwd=%s\n' "$*" "$PWD" >>"${SYNC_BUN_TEST_LOG:?}"
+printf '%s\n' "${SYNC_BUN_NODE_PTY_PACKAGE:?}"
+NODE
+
+cat >"$bun_install/bin/node-gyp" <<'NODE_GYP'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'node-gyp %s cwd=%s\n' "$*" "$PWD" >>"${SYNC_BUN_TEST_LOG:?}"
+if [[ "${SYNC_BUN_FAIL_REBUILD:-}" == 1 ]]; then
+  exit 24
+fi
+NODE_GYP
+chmod +x "$bun_install/bin/bun" "$bun_install/bin/node" "$bun_install/bin/node-gyp"
+
+run_sync() {
+  env \
+    BUN_INSTALL="$bun_install" \
+    DOTBINS_SHELL="$dotbins_shell" \
+    PATH="$shell_bin:/usr/bin:/bin" \
+    SYNC_BUN_NODE_PTY_PACKAGE="$node_pty_dir/package.json" \
+    SYNC_BUN_TEST_LOG="$log" \
+    "$@" \
+    "$shell_bin/bash" "$script" >"$test_root/output" 2>&1
+}
+
+if ! run_sync; then
+  printf 'sync-bun did not rebuild node-pty from the Node-resolved directory\n' >&2
+  exit 1
+fi
+grep -Fxq "node-gyp rebuild cwd=$node_pty_dir" "$log"
+if ! grep -Fxq "node -p require.resolve(\"node-pty/package.json\") cwd=$t3_dir" "$log"; then
+  printf 'sync-bun did not resolve node-pty relative to T3 global modules\n' >&2
+  exit 1
+fi
+
+: >"$log"
+if run_sync SYNC_BUN_FAIL_INSTALL=1; then
+  printf 'sync-bun unexpectedly masked a package install failure\n' >&2
+  exit 1
+fi
+
+: >"$log"
+if run_sync SYNC_BUN_FAIL_REBUILD=1; then
+  printf 'sync-bun unexpectedly masked a node-gyp rebuild failure\n' >&2
+  exit 1
+fi
+
+printf 'sync-bun tests passed\n'

--- a/tests/test-sync-secrets.sh
+++ b/tests/test-sync-secrets.sh
@@ -83,6 +83,14 @@ if [[ ! -L "$config_target" || "$(readlink "$config_target")" != "$secrets_dir/c
   exit 1
 fi
 
+rm "$config_target"
+ln -s "$test_root/missing-config.yaml" "$config_target"
+run_sync
+if [[ ! -L "$config_target" || "$(readlink "$config_target")" != "$secrets_dir/configs/zfs-unlock/config.yaml" ]]; then
+  printf 'pi4 did not repair a dangling ZFS-unlock config link\n' >&2
+  exit 1
+fi
+
 rm "$secrets_dir/configs/zfs-unlock/photos_key"
 if run_sync; then
   printf 'pi4 accepted a missing required ZFS-unlock key\n' >&2

--- a/tests/test-sync-secrets.sh
+++ b/tests/test-sync-secrets.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script="$repo_root/scripts/sync-secrets.sh"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+remote="$test_root/secrets-remote.git"
+seed="$test_root/secrets-seed"
+dotfiles_root="$test_root/dotfiles"
+secrets_dir="$test_root/secrets-checkout"
+config_target="$test_root/config/zfs-unlock/config.yaml"
+marker="$test_root/generic-installer-ran"
+output="$test_root/output"
+required_files=(
+  configs/zfs-unlock/config.yaml
+  configs/zfs-unlock/frigate_key
+  configs/zfs-unlock/photos_export_key
+  configs/zfs-unlock/photos_key
+  configs/zfs-unlock/stash_key
+  configs/zfs-unlock/zfs-unlock-receiver
+)
+
+git init --bare --initial-branch=main "$remote" >/dev/null
+git clone "$remote" "$seed" >/dev/null
+(
+  cd "$seed"
+  git config user.email test@example.invalid
+  git config user.name 'sync-secrets test'
+  for required_file in "${required_files[@]}"; do
+    mkdir -p "$(dirname "$required_file")"
+    if [[ "$required_file" == configs/zfs-unlock/config.yaml ]]; then
+      printf '%s\n' 'test-only-unlock-material' >"$required_file"
+    else
+      : >"$required_file"
+    fi
+  done
+  cat >install <<'INSTALL'
+#!/usr/bin/env bash
+set -euo pipefail
+touch "${SYNC_SECRETS_TEST_MARKER:?}"
+INSTALL
+  chmod +x install
+  git add configs/zfs-unlock install
+  git commit -m 'fixture secrets' >/dev/null
+  git push origin main >/dev/null
+)
+git clone "$remote" "$secrets_dir" >/dev/null
+mkdir -p "$dotfiles_root"
+ln -s "$secrets_dir" "$dotfiles_root/secrets"
+
+run_sync() {
+  env \
+    DOTFILES_ROOT="$dotfiles_root" \
+    SECRETS_DIR="$secrets_dir" \
+    SYNC_SECRETS_HOSTNAME=pi4 \
+    SYNC_SECRETS_TEST_MARKER="$marker" \
+    ZFS_UNLOCK_CONFIG_TARGET="$config_target" \
+    bash "$script" >"$output" 2>&1
+}
+
+mkdir -p "$(dirname "$config_target")"
+: >"$config_target"
+run_sync
+if [[ -e "$marker" ]]; then
+  printf 'pi4 unexpectedly invoked the generic secrets installer\n' >&2
+  exit 1
+fi
+if [[ -L "$config_target" ]]; then
+  printf 'pi4 replaced an existing ZFS-unlock config target\n' >&2
+  exit 1
+fi
+
+rm "$config_target"
+run_sync
+if [[ -e "$marker" ]]; then
+  printf 'pi4 unexpectedly invoked the generic secrets installer\n' >&2
+  exit 1
+fi
+if [[ ! -L "$config_target" || "$(readlink "$config_target")" != "$secrets_dir/configs/zfs-unlock/config.yaml" ]]; then
+  printf 'pi4 did not link the absent ZFS-unlock config target\n' >&2
+  exit 1
+fi
+
+rm "$secrets_dir/configs/zfs-unlock/photos_key"
+if run_sync; then
+  printf 'pi4 accepted a missing required ZFS-unlock key\n' >&2
+  exit 1
+fi
+if [[ -e "$marker" ]]; then
+  printf 'pi4 invoked the generic secrets installer after validation failed\n' >&2
+  exit 1
+fi
+if grep -Fq 'test-only-unlock-material' "$output"; then
+  printf 'pi4 printed secret material after validation failed\n' >&2
+  exit 1
+fi
+
+printf 'sync-secrets tests passed\n'

--- a/tests/test-sync-uv.sh
+++ b/tests/test-sync-uv.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script="$repo_root/scripts/sync-uv.sh"
+shell_bin=$(dirname "$(command -v bash)")
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+bin_dir="$test_root/bin"
+dotbins_shell="$test_root/dotbins-shell.sh"
+log="$test_root/commands.log"
+mkdir -p "$bin_dir"
+
+cat >"$dotbins_shell" <<'SHELL'
+export PATH="${SYNC_UV_TEST_BIN:?}:$PATH"
+SHELL
+
+cat >"$bin_dir/uv" <<'UV'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${SYNC_UV_TEST_LOG:?}"
+if [[ "${SYNC_UV_FAIL_INSTALL:-}" == 1 && "$*" == "tool install black" ]]; then
+  exit 23
+fi
+UV
+chmod +x "$bin_dir/uv"
+
+run_sync() {
+  env \
+    DOTBINS_SHELL="$dotbins_shell" \
+    PATH="$shell_bin:/usr/bin:/bin" \
+    SYNC_UV_TEST_BIN="$bin_dir" \
+    SYNC_UV_TEST_LOG="$log" \
+    "$@" \
+    "$shell_bin/bash" "$script" >"$test_root/output" 2>&1
+}
+
+if run_sync SYNC_UV_FAIL_INSTALL=1; then
+  status=0
+else
+  status=$?
+fi
+if ! grep -Fxq 'tool install black' "$log"; then
+  printf 'sync-uv could not find uv through the controlled Dotbins shell\n' >&2
+  cat "$test_root/output" >&2
+  exit 1
+fi
+if ((status == 0)); then
+  printf 'sync-uv unexpectedly masked a failed parallel install\n' >&2
+  exit 1
+fi
+
+: >"$log"
+run_sync
+grep -Fxq 'tool upgrade --all' "$log"
+
+printf 'sync-uv tests passed\n'


### PR DESCRIPTION
## Summary

- switch public submodules to HTTPS and harden update failure handling
- make Bun, uv, baspowers, and secrets installation noninteractive and host-aware
- add regression coverage for fleet installation and recovery invariants

## Tests

- `for test_script in tests/test-*.sh; do bash "$test_script"; done`
- `find scripts tests -type f -name "*.sh" -print0 | sort -z | xargs -0 bash -n`
- `git diff origin/main..HEAD --check`
- exact `.gitmodules` HTTPS URL assertions
- `git ls-remote` for every configured submodule URL