### PR TITLE
Install node-gyp before T3

### DIFF
--- a/scripts/sync-bun.sh
+++ b/scripts/sync-bun.sh
@@ -7,6 +7,9 @@ source "${DOTBINS_SHELL:-$HOME/.dotbins/shell/bash.sh}"
 export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
+# T3's node-pty postinstall requires node-gyp during package installation.
+bun install -g node-gyp@latest
+
 packages=(
     @google/gemini-cli@latest
     @just-every/code@latest
@@ -19,7 +22,6 @@ packages=(
 bun install -g "${packages[@]}"
 
 # T3's node-pty dependency has no Linux prebuild, so build its native addon.
-bun install -g node-gyp@latest
 node_pty_package=''
 t3_global_dir="$BUN_INSTALL/install/global/node_modules/t3"
 if ! node_pty_package=$(cd "$t3_global_dir" && node -p 'require.resolve("node-pty/package.json")'); then

--- a/tests/test-sync-bun.sh
+++ b/tests/test-sync-bun.sh
@@ -27,6 +27,13 @@ set -euo pipefail
 
 [[ "${SYNC_BUN_DOTBINS_SOURCED:-}" == 1 ]]
 printf 'bun %s\n' "$*" >>"${SYNC_BUN_TEST_LOG:?}"
+if [[ " $* " == *" t3@latest "* && ! -e "${SYNC_BUN_NODE_GYP_INSTALLED:?}" ]]; then
+  printf 'node-gyp must be installed before T3\n' >&2
+  exit 25
+fi
+if [[ " $* " == *" node-gyp@latest "* ]]; then
+  : >"$SYNC_BUN_NODE_GYP_INSTALLED"
+fi
 if [[ "${SYNC_BUN_FAIL_INSTALL:-}" == 1 ]]; then
   exit 23
 fi
@@ -58,12 +65,14 @@ run_sync() {
     PATH="$shell_bin:/usr/bin:/bin" \
     SYNC_BUN_TEST_COMMAND_BIN="$command_bin" \
     SYNC_BUN_NODE_PTY_PACKAGE="$node_pty_dir/package.json" \
+    SYNC_BUN_NODE_GYP_INSTALLED="$test_root/node-gyp-installed" \
     SYNC_BUN_TEST_LOG="$log" \
     "$@" \
     "$shell_bin/bash" "$script" >"$test_root/output" 2>&1
 }
 
 if ! run_sync; then
+  cat "$test_root/output" >&2
   printf 'sync-bun did not rebuild node-pty from the Node-resolved directory\n' >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- install `node-gyp` before the Bun package batch so T3 can build `node-pty` during postinstall
- keep the explicit dynamic `node-pty` rebuild after package installation
- add a regression test that rejects the old ordering

## Tests
- `bash tests/test-sync-bun.sh`
- `for test_file in tests/test-*.sh; do bash "$test_file"; done`
- `bash -n` for Bash scripts and tests
- `git diff origin/main..HEAD --check`
- exact HTTPS submodule URL assertions and remote `ls-remote` checks